### PR TITLE
Add possibility to set volume to more than 100%

### DIFF
--- a/portMenu.js
+++ b/portMenu.js
@@ -12,7 +12,8 @@ const Signals = imports.signals;
 
 
 const VOLUME_NOTIFY_ID = 1;
-const PA_MAX = 65536;
+const PA_FULL = 65536;
+const PA_MAX = PA_FULL * 1.5;
 
 const PortMenu = new Lang.Class({
 	Name: 'PortMenu',
@@ -37,6 +38,7 @@ const PortMenu = new Lang.Class({
 		this._icon = new St.Icon({style_class: 'sink-icon'});
 		let muteBtn = new St.Button({child: this._icon});
 		this._slider = new Slider.Slider(0);
+		this._label = new St.Label();
 
 		//Populate all the devices
 		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Get',
@@ -64,6 +66,7 @@ const PortMenu = new Lang.Class({
 		this.actor.add(muteBtn);
 		this.actor.add(this._slider.actor, {expand:true});
 		this.actor.add(this._expandBtn);
+		this.actor.add(this._label);
 
 		this.actor.add_style_class_name('stream');
 
@@ -381,6 +384,8 @@ const Device = new Lang.Class({
 
 			this._base.emit('icon-changed', this._base._slider.value);
 		}
+		let volPercent = this._base._slider.value * PA_MAX / PA_FULL * 100;
+		this._base._label.set_text(volPercent.toFixed().toString() + ' %');
 	},
 
 
@@ -420,6 +425,8 @@ const Device = new Lang.Class({
 			}
 		}
 		this._base.emit('icon-changed', this._base._slider.value);
+		let volPercent = this._base._slider.value * PA_MAX / PA_FULL * 100;
+		this._base._label.set_text(volPercent.toFixed().toString() + ' %');
 	},
 
 	_onPortChanged: function(conn, sender, object, iface, signal, param, user_data){


### PR DESCRIPTION
Would you consider adding the possibility to set volume to more than the current limit ? This can be useful for example on laptops with low-powered speakers.

This pull-request adds the possibility to set volume up to 150% and also adds a label indicating the volume level so that it's obvious when it's set to more than 100%.

The value of 150% is abitrary (it's approximately what you can set with pavucontrol), I also made a version in which the max value of the slider can be set through preferences but this seemed a bit too much, although I could make a pull request with it if you prefer.

Anyway thanks for your time and for sharing this extension.
