### PR TITLE
Modifications to deal with a bug in pulseaudio + small additions

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -102,32 +102,32 @@ const LaineCore = new Lang.Class({
 			this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 			this.addMenuItem(this._streamMenu);
 
-            let _settings = Convenience.getSettings();
-            let boolSettings=_settings.get_boolean('open-settings')
-            if (boolSettings) {
-                //this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
-                // TO DO allow to change application name in preferences
-                let _settingsAppName = _settings.get_string('app-settings');
-                //let _settingsAppName = 'pavucontrol';
+			let _settings = Convenience.getSettings();
+			let boolSettings=_settings.get_boolean('open-settings')
+			if (boolSettings) {
+				//this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+				// TO DO allow to change application name in preferences
+				let _settingsAppName = _settings.get_string('app-settings');
+				//let _settingsAppName = 'pavucontrol';
 
-                let _appSys = Shell.AppSystem.get_default();
-                let _settingsApp = _appSys.lookup_app(_settingsAppName+'.desktop');
-                    
-                this._settingsMenu  = new PopupMenu.PopupMenuItem(_('PulseAudio Settings'));
-                if (_settingsApp != null) {
-                    this._settingsMenu.connect('activate', function () {
-                        _settingsApp.activate();
-                        if(Main.panel.statusArea.laine) {
-                            Main.panel.statusArea.laine.menu.close();
-                        }
-                    });
-                } else {
-                    this._settingsMenu.setActive(false);
-                }
-                this.addMenuItem(this._settingsMenu);
-            }
-               
-            container.layout();
+				let _appSys = Shell.AppSystem.get_default();
+				let _settingsApp = _appSys.lookup_app(_settingsAppName+'.desktop');
+
+				this._settingsMenu  = new PopupMenu.PopupMenuItem(_('PulseAudio Settings'));
+				if (_settingsApp != null) {
+					this._settingsMenu.connect('activate', function () {
+						_settingsApp.activate();
+						if(Main.panel.statusArea.laine) {
+							Main.panel.statusArea.laine.menu.close();
+						}
+					});
+				} else {
+					this._settingsMenu.setActive(false);
+				}
+				this.addMenuItem(this._settingsMenu);
+			}
+
+			container.layout();
 		};
 
 		try{
@@ -172,6 +172,9 @@ const LaineCore = new Lang.Class({
 		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'ListenForSignal',
 			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSinkUpdated', []]),
 			null, Gio.DBusCallFlags.NONE, -1, null, null);
+		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'ListenForSignal',
+			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSinkUnset']),
+			null, Gio.DBusCallFlags.NONE, -1, null, null);
 
 		//Source listening
 		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'ListenForSignal',
@@ -182,6 +185,9 @@ const LaineCore = new Lang.Class({
 			null, Gio.DBusCallFlags.NONE, -1, null, null);
 		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'ListenForSignal',
 			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSourceUpdated', []]),
+			null, Gio.DBusCallFlags.NONE, -1, null, null);
+		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'ListenForSignal',
+			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSourceUnset']),
 			null, Gio.DBusCallFlags.NONE, -1, null, null);
 
 
@@ -262,6 +268,9 @@ const LaineCore = new Lang.Class({
 				GLib.Variant.new('(s)', ['org.PulseAudio.Core1.FallbackSinkUpdated']),
 				null, Gio.DBusCallFlags.NONE, -1, null, null);
 			this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'StopListeningForSignal',
+				GLib.Variant.new('(s)', ['org.PulseAudio.Core1.FallbackSinkUnset']),
+				null, Gio.DBusCallFlags.NONE, -1, null, null);
+			this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'StopListeningForSignal',
 				GLib.Variant.new('(s)', ['org.PulseAudio.Core1.NewSource']),
 				null, Gio.DBusCallFlags.NONE, -1, null, null);
 			this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'StopListeningForSignal',
@@ -269,6 +278,9 @@ const LaineCore = new Lang.Class({
 				null, Gio.DBusCallFlags.NONE, -1, null, null);
 			this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'StopListeningForSignal',
 				GLib.Variant.new('(s)', ['org.PulseAudio.Core1.FallbackSourceUpdated']),
+				null, Gio.DBusCallFlags.NONE, -1, null, null);
+			this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'StopListeningForSignal',
+				GLib.Variant.new('(s)', ['org.PulseAudio.Core1.FallbackSourceUnset']),
 				null, Gio.DBusCallFlags.NONE, -1, null, null);
 			this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'StopListeningForSignal',
 				GLib.Variant.new('(s)', ['org.PulseAudio.Core1.NewRecordStream']),
@@ -301,8 +313,8 @@ const Laine = new Lang.Class({
 		this._sigSettings = this._settings.connect(
 			'changed::open-settings',
 			this._switchLayout);
-        
-        this.laineCore = new LaineCore(this);
+
+		this.laineCore = new LaineCore(this);
 		return 0;
 	},
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -102,7 +102,27 @@ const LaineCore = new Lang.Class({
 			this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 			this.addMenuItem(this._streamMenu);
 
-			container.layout();
+            _settings = Convenience.getSettings();
+            let boolSettings=_settings.get_boolean('open-settings')
+            if (boolSettings) {
+                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                // TO DO allow to change application name in preferences
+                this._settingsAppName = 'pavucontrol';
+
+                let _appSys = Shell.AppSystem.get_default();
+                let _settingsApp = _appSys.lookup_app(this._settingsAppName+'.desktop');
+                    
+                this._settingsMenu  = new PopupMenu.PopupMenuItem(_('Settings...'));
+                this._settingsMenu.connect('activate', function () {
+                    if (_settingsApp != null) {
+                        _settingsApp.activate();
+                        //this.menu.close();
+                    }
+                });
+                this.addMenuItem(this._settingsMenu);
+            }
+               
+            container.layout();
 		};
 
 		try{
@@ -273,8 +293,11 @@ const Laine = new Lang.Class({
 		this._sigMerge = this._settings.connect(
 			'changed::'+this._key_MERGE_CONTROLS,
 			this._switchLayout);
-
-		this.laineCore = new LaineCore(this);
+		this._sigSettings = this._settings.connect(
+			'changed::open-settings',
+			this._switchLayout);
+        
+        this.laineCore = new LaineCore(this);
 		return 0;
 	},
 
@@ -347,7 +370,9 @@ const Laine = new Lang.Class({
 		}
 
 		this._settings.disconnect(this._sigMerge);
+		this._settings.disconnect(this._sigSettings);
 		this._sigMerge = null;
+		this._sigSettings = null;
 	}
 
 });

--- a/src/extension.js
+++ b/src/extension.js
@@ -409,7 +409,6 @@ const Laine = new Lang.Class({
 		}
 
 		this._settings.disconnect(this._sigMerge);
-		this._settings.disconnect(this._sigSettings);
 		this._sigMerge = null;
 		Main.panel._rightBox.disconnect(this._sigPanelListen);
 		this._sigPanelListen = null;

--- a/src/extension.js
+++ b/src/extension.js
@@ -102,23 +102,28 @@ const LaineCore = new Lang.Class({
 			this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 			this.addMenuItem(this._streamMenu);
 
-            _settings = Convenience.getSettings();
+            let _settings = Convenience.getSettings();
             let boolSettings=_settings.get_boolean('open-settings')
             if (boolSettings) {
-                this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+                //this.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
                 // TO DO allow to change application name in preferences
-                this._settingsAppName = 'pavucontrol';
+                let _settingsAppName = _settings.get_string('app-settings');
+                //let _settingsAppName = 'pavucontrol';
 
                 let _appSys = Shell.AppSystem.get_default();
-                let _settingsApp = _appSys.lookup_app(this._settingsAppName+'.desktop');
+                let _settingsApp = _appSys.lookup_app(_settingsAppName+'.desktop');
                     
-                this._settingsMenu  = new PopupMenu.PopupMenuItem(_('Settings...'));
-                this._settingsMenu.connect('activate', function () {
-                    if (_settingsApp != null) {
+                this._settingsMenu  = new PopupMenu.PopupMenuItem(_('PulseAudio Settings'));
+                if (_settingsApp != null) {
+                    this._settingsMenu.connect('activate', function () {
                         _settingsApp.activate();
-                        //this.menu.close();
-                    }
-                });
+                        if(Main.panel.statusArea.laine) {
+                            Main.panel.statusArea.laine.menu.close();
+                        }
+                    });
+                } else {
+                    this._settingsMenu.setActive(false);
+                }
                 this.addMenuItem(this._settingsMenu);
             }
                

--- a/src/extension.js
+++ b/src/extension.js
@@ -173,7 +173,7 @@ const LaineCore = new Lang.Class({
 			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSinkUpdated', []]),
 			null, Gio.DBusCallFlags.NONE, -1, null, null);
 		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'ListenForSignal',
-			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSinkUnset']),
+			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSinkUnset', []]),
 			null, Gio.DBusCallFlags.NONE, -1, null, null);
 
 		//Source listening
@@ -187,7 +187,7 @@ const LaineCore = new Lang.Class({
 			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSourceUpdated', []]),
 			null, Gio.DBusCallFlags.NONE, -1, null, null);
 		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.PulseAudio.Core1', 'ListenForSignal',
-			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSourceUnset']),
+			GLib.Variant.new('(sao)', ['org.PulseAudio.Core1.FallbackSourceUnset', []]),
 			null, Gio.DBusCallFlags.NONE, -1, null, null);
 
 
@@ -413,5 +413,5 @@ function disable(){
 		delete Main.panel.statusArea.laine;
 	else
 		delete Main.panel.statusArea.aggregateMenu._laine;
-	delete _menuButton;
+	_menuButton = null;
 }

--- a/src/portMenu.js
+++ b/src/portMenu.js
@@ -83,13 +83,13 @@ const PortMenu = new Lang.Class({
 
 
         this._sigFallback = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'Fallback'+type+'Updated',
-            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange));
         this._sigFallbackUnset = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'Fallback'+type+'Unset',
-            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange));
         this._sigNewDevice = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'New'+type,
-            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange));
         this._sigRemovedDevice = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', type+'Removed',
-            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange));
 
         this.actor.connect('scroll-event', Lang.bind(this, this.scroll));
         this.actor.connect('destroy', Lang.bind(this, this._onDestroy));

--- a/src/portMenu.js
+++ b/src/portMenu.js
@@ -152,7 +152,7 @@ const PortMenu = new Lang.Class({
                 })
             );
             return false; // Don't repeat
-        }), null);
+        }));
     },
 
     _initFallbackDevice: function(paConn, type) {
@@ -500,14 +500,14 @@ const Device = new Lang.Class({
 
     setActiveDevice: function(){
         this._sigVol = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'VolumeUpdated',
-            this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onVolumeChanged), null );
+            this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onVolumeChanged));
         this._asyncDBusGetProperty('Volume', Lang.bind(this, function(conn, query){
             let volV = conn.call_finish(query).get_child_value(0).unpack();
             this.setVolume(volV);
         }));
 
         this._sigMute = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'MuteUpdated',
-            this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onVolumeChanged), null );
+            this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onVolumeChanged));
         this._asyncDBusGetProperty('Mute', Lang.bind(this, function(conn, query){
             let muteV = conn.call_finish(query).get_child_value(0).unpack();
             this.setVolume(muteV);
@@ -515,7 +515,7 @@ const Device = new Lang.Class({
 
         if (this._numPorts > 0) {
             this._sigPort = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'ActivePortUpdated',
-                this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onPortChanged), null );
+                this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onPortChanged));
             this._asyncDBusGetProperty('ActivePort', Lang.bind(this, function(conn, query){
                 let response = conn.call_finish(query).get_child_value(0).unpack();
                 let port = response.get_string()[0];

--- a/src/portMenu.js
+++ b/src/portMenu.js
@@ -235,7 +235,9 @@ const PortMenu = new Lang.Class({
     },
 
     setVolume: function(volume){
-        this._activeDevice.setVolume(volume);
+        if(this._activeDevice != undefined) {
+            this._activeDevice.setVolume(volume);
+        };
     },
 
     _notifyVolumeChange: function() {
@@ -281,12 +283,18 @@ const PortMenu = new Lang.Class({
     },
 
     _onDevChange: function(conn, sender, object, iface, signal, param, user_data){
-        let addr = param.get_child_value(0).get_string()[0];
-
+        let addr = null;
+        try {
+            addr = param.get_child_value(0).get_string()[0];
+        } catch(err){
+            if(!(err instanceof TypeError)) {
+                throw err;
+            };
+        };
+        
         if (signal == 'Fallback'+ this._type +'Updated') {
             this._setActiveDevice(this._devices[addr]);
         } else if (signal == 'Fallback'+ this._type +'Unset') {
-            log("Fallback Unset");
             this._unsetActiveDevice();
         } else if (signal == 'New'+this._type) {
             this._addDevice(addr);

--- a/src/portMenu.js
+++ b/src/portMenu.js
@@ -19,671 +19,698 @@ const Convenience = Me.imports.convenience;
 const VOLUME_NOTIFY_ID = 1;
 const PA_MAX = 65536;
 
+const UPDATE_FALLBACK = true;
+const UPDATE_FALLBACK_REPEAT_MAX = 1;
+const UPDATE_FALLBACK_DELAY = 1000; //ms
 const UPDATE_FALLBACK_SINK_CMD = "/usr/bin/sh -c  \"/usr/bin/pacmd set-default-sink $(/usr/bin/pacmd list-sinks | awk '/* index:/ {print $3}')\"";
 const UPDATE_FALLBACK_SOURCE_CMD = "/usr/bin/sh -c  \"/usr/bin/pacmd set-default-source $(/usr/bin/pacmd list-sources | awk '/* index:/ {print $3}')\"";
 const UPDATE_FALLBACK_CMD = {'Sink': UPDATE_FALLBACK_SINK_CMD, 'Source': UPDATE_FALLBACK_SOURCE_CMD};
 
 const PortMenu = new Lang.Class({
-	Name: 'PortMenu',
-	Extends: PopupMenu.PopupSubMenuMenuItem,
-	Abstract: true,
+    Name: 'PortMenu',
+    Extends: PopupMenu.PopupSubMenuMenuItem,
+    Abstract: true,
 
-	_init: function(parent, paconn, type){
-		this.parent('', true);
-		this._parent = parent;
-		this._type = type;
+    _init: function(parent, paconn, type){
+        this.parent('', true);
+        this._parent = parent;
+        this._type = type;
+        this._isBlockedDbus = false;
 
-		let children = this.actor.get_children();
-		this._expandBtn = children[children.length - 1];
-		for(let i = 0; i < children.length -1; i++)
-			children[i].destroy();
-		this.actor.remove_actor(this._expandBtn);
-		this._expandBtn.hide();
-		
-		this._paDBus = paconn;
-		this._devices = {};
+        let children = this.actor.get_children();
+        this._expandBtn = children[children.length - 1];
+        for(let i = 0; i < children.length -1; i++)
+            children[i].destroy();
+        this.actor.remove_actor(this._expandBtn);
+        this._expandBtn.hide();
 
-		this._icon = new St.Icon({style_class: 'port-icon'});
-		this._nameLbl = new St.Label({text:"test"});
-		let muteBtn = new St.Button({child: this._icon});
-		this._slider = new Slider.Slider(0);
+        this._paDBus = paconn;
+        this._devices = {};
 
-		//Asynchronously populate all the devices
-		this._initDevices(this._paDBus, this._type);
+        this._icon = new St.Icon({style_class: 'port-icon'});
+        this._nameLbl = new St.Label({text:"test"});
+        let muteBtn = new St.Button({child: this._icon});
+        this._slider = new Slider.Slider(0);
 
-		//Laying stuff out
-		this.actor.add(muteBtn);
-		let container = new St.BoxLayout({vertical:true});
-		container.add(this._nameLbl);
-		container.add(this._slider.actor, {expand:true});
-		this.actor.add(container, {expand:true});
-		//this.actor.add(this._slider.actor, {expand:true});
-		this.actor.add(this._expandBtn);
+        //Asynchronously populate all the devices
+        this._initDevices(this._paDBus, this._type);
 
-		this.actor.add_style_class_name('port');
+        //Laying stuff out
+        this.actor.add(muteBtn);
+        let container = new St.BoxLayout({vertical:true});
+        container.add(this._nameLbl);
+        container.add(this._slider.actor, {expand:true});
+        this.actor.add(container, {expand:true});
+        //this.actor.add(this._slider.actor, {expand:true});
+        this.actor.add(this._expandBtn);
 
-		//Add listeners
-		this._slider.connect('value-changed', Lang.bind(this, function(slider, value, property){
-				this.setVolume(value);
-			})
-		);
-		this._slider.connect('drag-end', Lang.bind(this, this._notifyVolumeChange));
-		muteBtn.connect('clicked', Lang.bind(this, function(){
-				this.setVolume(!this._activeDevice._muteVal);
-			})
-		);
+        this.actor.add_style_class_name('port');
 
-
-		this._settings = Convenience.getSettings();
-		this._key_SHOW_LABEL = Me.imports.prefs.KEY_PORT_LABEL;
+        //Add listeners
+        this._slider.connect('value-changed', Lang.bind(this, function(slider, value, property){
+                this.setVolume(value);
+            })
+        );
+        this._slider.connect('drag-end', Lang.bind(this, this._notifyVolumeChange));
+        muteBtn.connect('clicked', Lang.bind(this, function(){
+                this.setVolume(!this._activeDevice._muteVal);
+            })
+        );
 
 
-		this._sigFallback = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'Fallback'+type+'Updated',
-			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
-		this._sigNewDevice = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'New'+type,
-			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
-		this._sigRemovedDevice = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', type+'Removed',
-			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
-
-		this.actor.connect('scroll-event', Lang.bind(this, this.scroll));
-		this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
-		this._sigShowLabel = this._settings.connect('changed::'+this._key_SHOW_LABEL, Lang.bind(this, this._setNameLabelVisiblity));
-
-		this._setNameLabelVisiblity();
-	},
-
-	_initDevices: function(paConn, type) {
-		// Asynchronous call to dbus
-		paConn.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1', type+'s']), GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
-			Lang.bind(this, function(conn, query){
-				let response = conn.call_finish(query).get_child_value(0).unpack();
-				for(let i = 0; i < response.n_children(); i++){
-					let devicePath = response.get_child_value(i).get_string()[0];
-					this._addDevice(devicePath);
-				};
-				//Got all the devices, so lets find the default one.
-				this._initFallbackDevice(paConn, type);
-			})
-		);
-	},
-
-	_initFallbackDevice: function(paConn, type) {
-		// Bug in PulseAudio DBus: fallback device is not updated when it is removed
-		//reset default device
-		Util.spawnCommandLine(UPDATE_FALLBACK_CMD[this._type]);
-		// Asynchronous call to dbus
-		paConn.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1', 'Fallback'+type]), GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
-			Lang.bind(this, function(conn, query){
-				try {
-					let response = conn.call_finish(query);
-					let fallback = response.get_child_value(0).unpack().get_string()[0];
-					if (fallback in this._devices) {
-						this._setActiveDevice(this._devices[fallback]);
-					};
-				} catch(err){
-					//pulseaudio does something which creates, and then deletes a device when switching sinks.  Therefore the fallback is not well defined.
-					if(!err.message.startsWith(" Gio.IOErrorEnum: GDBus.Error:org.PulseAudio.Core1.NoSuchPropertyError: There are no sinks, and therefore no fallback sink either.")) {
-						throw err;
-					} else {
-						log('Warning: ' + err.message);
-					};
-				};
-			})
-		);
-	},
-
-	_onKeyPressEvent: function(actor, event) {
-		let key = event.get_key_symbol();
-
-		if(key == Clutter.KEY_Right || key == Clutter.KEY_Left){
-			this._slider.onKeyPressEvent(actor, event);
-			return Clutter.EVENT_STOP;
-		}
-		else if(key == Clutter.KEY_space){
-			this.setVolume(!this._activeDevice._muteVal);
-			return Clutter.EVENT_STOP;
-		}
-		else if(key == Clutter.KEY_Return) {
-			this._setOpenState(!this._getOpenState());
-			return Clutter.EVENT_STOP;
-		}
-
-		return this.parent(actor, event);
-	},
-
-	_addDevice: function(path) {
-		let device = new Device(path, this._paDBus, this);
-		this._devices[path] = device;
-		// Bug in PulseAudio DBus: fallback device is not updated when it is removed
-		if (this._activeDeviceTempPath != undefined || this._activeDeviceTempPath != null) {
-			delete this._activeDeviceTempPath;
-			this._initFallbackDevice(this._paDBus, this._type);
-			////set active device to the same sink address
-			//Util.spawnCommandLine(UPDATE_FALLBACK_CMD[this._type]);
-
-			//this._setActiveDevice(this._devices[path]);
-			////log("Warning: Active Device defined again: "+path);
-		};
-		
-	},
-
-	_removeDevice: function(path) {
-		if(path in this._devices){
-			// Bug in PulseAudio DBus: fallback device is not updated when it is removed
-			if (this._activeDevice == this._devices[path]) {
-				this._activeDeviceTempPath = path;
-				this._initFallbackDevice(this._paDBus, this._type);
-				//Util.spawnCommandLine(UPDATE_FALLBACK_CMD[this._type]);
-			};
-
-			//remove device
-			this._devices[path].destroy();
-			delete this._devices[path];
-
-			this._updateExpandBtnVisiblity();
-		};
-	},
-
-	_setActiveDevice: function(dev){
-		if(this._activeDevice != undefined && this._activeDevice._path in this._devices) {
-			this._activeDevice.unsetActiveDevice();
-		};
-
-		this._activeDevice = dev;
-		this._activeDevice.setActiveDevice();
-	},
-
-	setVolume: function(volume){
-		this._activeDevice.setVolume(volume);
-	},
-
-	_notifyVolumeChange: function() {
-		global.cancel_theme_sound(VOLUME_NOTIFY_ID);
-		global.play_theme_sound(VOLUME_NOTIFY_ID,
-			'audio-volume-change',
-			_("Volume changed"),
-			Clutter.get_current_event ());
-	},
-
-	scroll: function(actor, event){
-		return this._slider.scroll(event);
-	},
+        this._settings = Convenience.getSettings();
+        this._key_SHOW_LABEL = Me.imports.prefs.KEY_PORT_LABEL;
 
 
-	//Some abstract methods
-	_setMuteIcon: function(desc){},
-	_isExpandBtnVisible: function(){},
-	_isVisble: function(){},
+        this._sigFallback = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'Fallback'+type+'Updated',
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
+        this._sigFallbackUnset = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'Fallback'+type+'Unset',
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
+        this._sigNewDevice = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'New'+type,
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
+        this._sigRemovedDevice = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', type+'Removed',
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onDevChange), null );
 
-	_updateExpandBtnVisiblity: function(){
-		let set = this._isExpandBtnVisible();
-		if(set)
-			this._expandBtn.show();
-		else 
-			this._expandBtn.hide();
-	},
+        this.actor.connect('scroll-event', Lang.bind(this, this.scroll));
+        this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
+        this._sigShowLabel = this._settings.connect('changed::'+this._key_SHOW_LABEL, Lang.bind(this, this._setNameLabelVisiblity));
 
-	_setNameLabelVisiblity: function(){
-		let vis = this._settings.get_boolean(this._key_SHOW_LABEL);
-		if(vis)
-			this._nameLbl.show();
-		else
-			this._nameLbl.hide();
-	},
+        this._setNameLabelVisiblity();
+    },
 
-	_updateVisibility: function(){
-		let vis = this._isVisible();
-		if(vis)
-			this.actor.show();
-		else
-			this.actor.hide();
-	},
+    _initDevices: function(paConn, type) {
+        // Asynchronous call to dbus
+        paConn.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Get',
+            GLib.Variant.new('(ss)', ['org.PulseAudio.Core1', type+'s']), GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
+            Lang.bind(this, function(conn, query){
+                let response = conn.call_finish(query).get_child_value(0).unpack();
+                for(let i = 0; i < response.n_children(); i++){
+                    let devicePath = response.get_child_value(i).get_string()[0];
+                    this._addDevice(devicePath);
+                };
+                //Got all the devices, so lets find the default one.
+                this._forceFallbackDevice(paConn, type, 0);
+            })
+        );
+    },
 
-	_onDevChange: function(conn, sender, object, iface, signal, param, user_data){
-		let addr = param.get_child_value(0).get_string()[0];
-		
-		if(signal == 'Fallback'+ this._type +'Updated' ){
-			if(this._activeDevice != undefined) {
-				this._activeDevice.unsetActiveDevice();
-			};
-			this._activeDevice = this._devices[addr];
-			this._activeDevice.setActiveDevice();
-		} 
-		else if(signal == 'New'+this._type )
-			this._addDevice(addr);
-		else if(signal == this._type + 'Removed'){
-			this._removeDevice(addr);
-		}
-	},
+    _forceFallbackDevice: function(paConn, type, repeat) {
+        // Bug in PulseAudio DBus: fallback device is not updated when it is removed
+        if (UPDATE_FALLBACK == true && this._isBlockedDbus == true) {
+            //reset default device (asynchronous shell command)
+            Util.spawnCommandLine(UPDATE_FALLBACK_CMD[type]);
+        };
+        //add a timeout for the shell cmd to finish
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, UPDATE_FALLBACK_DELAY, Lang.bind(this, function() {
+            // Asynchronous call to dbus
+            paConn.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Get',
+                GLib.Variant.new('(ss)', ['org.PulseAudio.Core1', 'Fallback'+type]), GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
+                Lang.bind(this, function(conn, query){
+                    try {
+                        let response = conn.call_finish(query);
+                        let fallback = response.get_child_value(0).unpack().get_string()[0];
+                        if (fallback in this._devices) {
+                            this._setActiveDevice(this._devices[fallback]);
+                        };
+                        this._isBlockedDbus = false;
 
-	_onDestroy: function(){
-		this._paDBus.signal_unsubscribe(this._sigFallback);
-		this._paDBus.signal_unsubscribe(this._sigNewDevice);
-		this._paDBus.signal_unsubscribe(this._sigRemovedDevice);
-		if(this._sigShowLabel){
-			this._settings.disconnect(this._sigShowLabel);
-			delete this._sigShowLabel;
-		}
-	}
-	
+                    } catch(err){
+                        //Bug in PulseAudio DBus: fallback device is not updated when it is removed
+                        if(!err.message.startsWith("GDBus.Error:org.PulseAudio.Core1.NoSuchPropertyError: There are no sinks, and therefore no fallback sink either.")) {
+                            throw err;
+                        } else {
+                            this._isBlockedDbus = true;
+                            // Repeat until max repetition is reached
+                            if (UPDATE_FALLBACK == true && repeat+1 <= UPDATE_FALLBACK_REPEAT_MAX) {
+                                // recursive call
+                                let info = "[" + err.fileName + " " + err.lineNumber + "]: ";
+                                log(info + "recursive call to _forceFallbackDevice #"+(repeat+1));
+                                this._forceFallbackDevice(paConn, type, repeat+1);
+                            };
+                        };
+                    };
+                })
+            );
+            return false; // Don't repeat
+        }), null);
+    },
+
+    _initFallbackDevice: function(paConn, type) {
+        // Asynchronous call to dbus
+        paConn.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Get',
+            GLib.Variant.new('(ss)', ['org.PulseAudio.Core1', 'Fallback'+type]), GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
+            Lang.bind(this, function(conn, query){
+                try {
+                    let response = conn.call_finish(query);
+                    let fallback = response.get_child_value(0).unpack().get_string()[0];
+                    if (fallback in this._devices) {
+                        this._setActiveDevice(this._devices[fallback]);
+                    };
+
+                } catch(err){
+                    //Bug in PulseAudio DBus: fallback device is not updated when it is removed
+                    if(!err.message.startsWith("GDBus.Error:org.PulseAudio.Core1.NoSuchPropertyError: There are no sinks, and therefore no fallback sink either.")) {
+                        throw err;
+                    };
+                };
+            })
+        );
+    },
+
+    _onKeyPressEvent: function(actor, event) {
+        let key = event.get_key_symbol();
+
+        if(key == Clutter.KEY_Right || key == Clutter.KEY_Left){
+            this._slider.onKeyPressEvent(actor, event);
+            return Clutter.EVENT_STOP;
+        }
+        else if(key == Clutter.KEY_space){
+            this.setVolume(!this._activeDevice._muteVal);
+            return Clutter.EVENT_STOP;
+        }
+        else if(key == Clutter.KEY_Return) {
+            this._setOpenState(!this._getOpenState());
+            return Clutter.EVENT_STOP;
+        }
+
+        return this.parent(actor, event);
+    },
+
+    _addDevice: function(path) {
+        let device = new Device(path, this._paDBus, this);
+        this._devices[path] = device;
+        // Bug in PulseAudio DBus: fallback device is not updated when it is removed
+        if (UPDATE_FALLBACK == true && this._isBlockedDbus == true) {
+            this._forceFallbackDevice(this._paDBus, this._type, 0);
+        };
+    },
+
+    _removeDevice: function(path) {
+        if(path in this._devices){
+            // Bug in PulseAudio DBus: fallback device is not updated when it is removed
+            if (UPDATE_FALLBACK == true && this._activeDevice == this._devices[path]) {
+                this._isBlockedDbus = true;
+                this._forceFallbackDevice(this._paDBus, this._type, 0);
+            };
+
+            //remove device
+            this._devices[path].destroy();
+            delete this._devices[path];
+
+            this._updateExpandBtnVisiblity();
+        };
+    },
+
+    _unsetActiveDevice: function(){
+        if(this._activeDevice != undefined && this._activeDevice._path in this._devices) {
+            this._activeDevice.unsetActiveDevice();
+        };
+    },
+
+    _setActiveDevice: function(dev){
+        this._unsetActiveDevice()
+
+        this._activeDevice = dev;
+        this._activeDevice.setActiveDevice();
+    },
+
+    setVolume: function(volume){
+        this._activeDevice.setVolume(volume);
+    },
+
+    _notifyVolumeChange: function() {
+        global.cancel_theme_sound(VOLUME_NOTIFY_ID);
+        global.play_theme_sound(VOLUME_NOTIFY_ID,
+            'audio-volume-change',
+            _("Volume changed"),
+            Clutter.get_current_event ());
+    },
+
+    scroll: function(actor, event){
+        return this._slider.scroll(event);
+    },
+
+
+    //Some abstract methods
+    _setMuteIcon: function(desc){},
+    _isExpandBtnVisible: function(){},
+    _isVisble: function(){},
+
+    _updateExpandBtnVisiblity: function(){
+        let set = this._isExpandBtnVisible();
+        if(set)
+            this._expandBtn.show();
+        else
+            this._expandBtn.hide();
+    },
+
+    _setNameLabelVisiblity: function(){
+        let vis = this._settings.get_boolean(this._key_SHOW_LABEL);
+        if(vis)
+            this._nameLbl.show();
+        else
+            this._nameLbl.hide();
+    },
+
+    _updateVisibility: function(){
+        let vis = this._isVisible();
+        if(vis)
+            this.actor.show();
+        else
+            this.actor.hide();
+    },
+
+    _onDevChange: function(conn, sender, object, iface, signal, param, user_data){
+        let addr = param.get_child_value(0).get_string()[0];
+
+        if (signal == 'Fallback'+ this._type +'Updated') {
+            this._setActiveDevice(this._devices[addr]);
+        } else if (signal == 'Fallback'+ this._type +'Unset') {
+            log("Fallback Unset");
+            this._unsetActiveDevice();
+        } else if (signal == 'New'+this._type) {
+            this._addDevice(addr);
+        } else if (signal == this._type + 'Removed') {
+            this._removeDevice(addr);
+        }
+    },
+
+    _onDestroy: function(){
+        this._paDBus.signal_unsubscribe(this._sigFallback);
+        this._paDBus.signal_unsubscribe(this._sigFallbackUnset);
+        this._paDBus.signal_unsubscribe(this._sigNewDevice);
+        this._paDBus.signal_unsubscribe(this._sigRemovedDevice);
+        if(this._sigShowLabel){
+            this._settings.disconnect(this._sigShowLabel);
+            delete this._sigShowLabel;
+        }
+    },
 });
 
 const Port = new Lang.Class({
-	Name: 'PulsePort',
-	Extends: PopupMenu.PopupMenuItem,
+    Name: 'PulsePort',
+    Extends: PopupMenu.PopupMenuItem,
 
-	_init: function(path, paconn, device){
-		this.parent('');
-		this._paDBus = paconn;
-		this._path = path;
-		this._device = device
-		this._type = '';
+    _init: function(path, paconn, device){
+        this.parent('');
+        this._paDBus = paconn;
+        this._path = path;
+        this._device = device
+        this._type = '';
 
-		this._paDBus.call(null, path, 'org.freedesktop.DBus.Properties', 'GetAll',
-			GLib.Variant.new('(s)', ['org.PulseAudio.Core1.DevicePort']), 
-			GLib.VariantType.new("(a{sv})"), Gio.DBusCallFlags.NONE, -1, null,
-			Lang.bind(this, function(conn, query){
-				let response = conn.call_finish(query).get_child_value(0);
+        this._paDBus.call(null, path, 'org.freedesktop.DBus.Properties', 'GetAll',
+            GLib.Variant.new('(s)', ['org.PulseAudio.Core1.DevicePort']),
+            GLib.VariantType.new("(a{sv})"), Gio.DBusCallFlags.NONE, -1, null,
+            Lang.bind(this, function(conn, query){
+                try{
+                    let response = conn.call_finish(query).get_child_value(0);
 
-				for(let i = 0; i < response.n_children(); i++){
-					let [key, value] = response.get_child_value(i).unpack();
-					key = key.get_string()[0];
-					if(key == "Name")
-						this._type = value.unpack().get_string()[0];
-					else if(key == "Description")
-						this._name = value.unpack().get_string()[0];
-				}
+                    for(let i = 0; i < response.n_children(); i++){
+                        let [key, value] = response.get_child_value(i).unpack();
+                        key = key.get_string()[0];
+                        if(key == "Name")
+                            this._type = value.unpack().get_string()[0];
+                        else if(key == "Description")
+                            this._name = value.unpack().get_string()[0];
+                    }
 
-				this.label.set_text(this.getName());
-				this.emit('name-set');
-			})
-		);
+                    this.label.set_text(this.getName());
+                    this.emit('name-set');
+                } catch(err){
+                    //pulseaudio does something which creates, and then deletes a card when switching sources.  Therefore the listener will trigger this,
+                    //but by the time we can query anything from it, it's already gone.  Therefore ignore this exception.
+                    if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Method \"GetAll\" with signature"))
+                        throw err;
+                };
+            })
+        );
 
-		this.connect('activate', Lang.bind(this._device, this._device._onPortSelect));
-	},
+        this.connect('activate', Lang.bind(this._device, this._device._onPortSelect));
+    },
 
-	getName: function(){
-		let name = this._device._name;
-		if(this._device._numPorts > 1)
-			name = name.concat(": ", this._name);
-		return name;
-	},
+    getName: function(){
+        let name = this._device._name;
+        if(this._device._numPorts > 1)
+            name = name.concat(": ", this._name);
+        return name;
+    },
 
-	_giveName: function(textCallback){
-		let name = this._name;
-		let sigId;
-		if(name === undefined){
-			sigId = this.connect('name-set', Lang.bind(this, function(){
-				textCallback(this.getName(), this._type);
-				this.disconnect(sigId);
-			}));
-		} else {
-			textCallback(this.getName(), this._type);
-		}
-	}
+    _giveName: function(textCallback){
+        let name = this._name;
+        let sigId;
+        if(name === undefined){
+            sigId = this.connect('name-set', Lang.bind(this, function(){
+                textCallback(this.getName(), this._type);
+                this.disconnect(sigId);
+            }));
+        } else {
+            textCallback(this.getName(), this._type);
+        }
+    }
 
 });
 
 const VirtualPort = new Lang.Class({
-	Name: 'PulseVirtualPort',
-	Extends: PopupMenu.PopupMenuItem,
+    Name: 'PulseVirtualPort',
+    Extends: PopupMenu.PopupMenuItem,
 
-	_init: function(path, paconn, device){
-		this.parent('');
-		this._paDBus = paconn;
-		this._path = path;
-		this._device = device
+    _init: function(path, paconn, device){
+        this.parent('');
+        this._paDBus = paconn;
+        this._path = path;
+        this._device = device
 
-		this._type = 'virtual';
-		this._name = this._device._name;
-		this.label.set_text(this.getName());
-		this.emit('name-set');
+        this._type = 'virtual';
+        this._name = this._device._name;
+        this.label.set_text(this.getName());
+        this.emit('name-set');
 
-		this.connect('activate', Lang.bind(this._device, this._device._onPortSelect));
-	},
+        this.connect('activate', Lang.bind(this._device, this._device._onPortSelect));
+    },
 
-	getName: function(){
-		let name = this._device._name;
-		if(this._device._numPorts > 1)
-			name = name.concat(": ", this._name);
-		return name;
-	},
+    getName: function(){
+        let name = this._device._name;
+        if(this._device._numPorts > 1)
+            name = name.concat(": ", this._name);
+        return name;
+    },
 
-	_giveName: function(textCallback){
-		let name = this._name;
-		let sigId;
-		if(name === undefined){
-			sigId = this.connect('name-set', Lang.bind(this, function(){
-				textCallback(this.getName(), this._type);
-				this.disconnect(sigId);
-			}));
-		} else {
-			textCallback(this.getName(), this._type);
-		}
-	}
+    _giveName: function(textCallback){
+        let name = this._name;
+        let sigId;
+        if(name === undefined){
+            sigId = this.connect('name-set', Lang.bind(this, function(){
+                textCallback(this.getName(), this._type);
+                this.disconnect(sigId);
+            }));
+        } else {
+            textCallback(this.getName(), this._type);
+        }
+    }
 
 });
 
 
 const Device = new Lang.Class({
-	Name: 'PulseDevice',
+    Name: 'PulseDevice',
 
-	_init: function(path, paconn, base){
-		this._paDBus = paconn;
-		this._path = path;
-		this._ports = {};
-		this._virtual = null;
-		this._base = base;
-		this._activePort = null;
+    _init: function(path, paconn, base){
+        this._paDBus = paconn;
+        this._path = path;
+        this._ports = {};
+        this._virtual = null;
+        this._base = base;
+        this._activePort = null;
 
-		this._settings = Convenience.getSettings();
-		this._key_PA_OVERDRIVE = Me.imports.prefs.KEY_PA_OVER;
+        this._settings = Convenience.getSettings();
+        this._key_PA_OVERDRIVE = Me.imports.prefs.KEY_PA_OVER;
 
-		this._sigVol = this._sigMute = this._sigPort = 0;
-		this._numPorts = 0;
+        this._sigVol = this._sigMute = this._sigPort = 0;
+        this._numPorts = 0;
 
 
-		this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Device', 'PropertyList']),
-			GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				let name = '['+this._path+']';
-				try{
-					let properties = conn.call_finish(query).get_child_value(0).unpack();
-					for(let i = properties.n_children(); i-- > 0;){
-						let [index, value]= properties.get_child_value(i).unpack();
-						let key = index.get_string()[0];
-						if(key == 'alsa.card_name' || key == 'device.description'){
-							name = String(value.unpack());
-							break;
-						}
-					}
-				} catch(err){
-					//pulseaudio does something which creates, and then deletes a card when switching sources.  Therefore the listener will trigger this,
-					//but by the time we can query anything from it, it's already gone.  Therefore ignore this exception.
-					if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Method \"Get\" with signature \"ss\""))
-						throw err;
-				}
-				this._name = name;
-			})
-		);
+        this._asyncDBusGetProperty('PropertyList', Lang.bind(this, function(conn, query){
+            let name = '['+this._path+']';
+            let properties = conn.call_finish(query).get_child_value(0).unpack();
+            for(let i = properties.n_children(); i-- > 0;){
+                let [index, value]= properties.get_child_value(i).unpack();
+                let key = index.get_string()[0];
+                if(key == 'alsa.card_name' || key == 'device.description'){
+                    name = String(value.unpack());
+                    break;
+                }
+            }
+            this._name = name;
+        }));
 
-		this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Device', 'Ports']), 
-			GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
-			Lang.bind(this, function(conn, query){
-					try{
-						let portPaths = conn.call_finish(query).get_child_value(0).unpack();
-						this._numPorts = portPaths.n_children(); 
-						if (this._numPorts > 0) {
-							this._virtual = null;
-							for(let j = 0; j < this._numPorts; j++){
-								let val = portPaths.get_child_value(j);
-								if(val != null) {
-									let portPath = val.get_string()[0];
-									let port = new Port(portPath, this._paDBus, this);
-									this._ports[portPath] = port;
-									this._base.menu.addMenuItem(port);
+        this._asyncDBusGetProperty('Ports', Lang.bind(this, function(conn, query){
+            let portPaths = conn.call_finish(query).get_child_value(0).unpack();
+            this._numPorts = portPaths.n_children();
+            if (this._numPorts > 0) {
+                this._virtual = null;
+                for(let j = 0; j < this._numPorts; j++){
+                    let val = portPaths.get_child_value(j);
+                    if(val != null) {
+                        let portPath = val.get_string()[0];
+                        let port = new Port(portPath, this._paDBus, this);
+                        this._ports[portPath] = port;
+                        this._base.menu.addMenuItem(port);
 
-									this._base._updateExpandBtnVisiblity();
-								}
-							}
-						} else if(this._base._type == 'Sink') {
-							this._virtual = new VirtualPort(this._path, this._paDBus, this);
-							this._base.menu.addMenuItem(this._virtual);
-							this._base._updateExpandBtnVisiblity();
-							//log('Device', this._name, ', Virtual:', this._path);
-						}
-					} catch(err){
-						//pulseaudio does something which creates, and then deletes a card when switching sources.  Therefore the listener will trigger this,
-						//but by the time we can query anything from it, it's already gone.  Therefore ignore this exception.
-						if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Method \"Get\" with signature \"ss\""))
-							throw err;
-					}
-				}
-			)
-		);
-		
-		this._setOverdriveLevel();
-		this._sigOverdrive = this._settings.connect('changed::'+this._key_PA_OVERDRIVE, Lang.bind(this, this._setOverdriveLevel));
+                        this._base._updateExpandBtnVisiblity();
+                    }
+                }
+            } else if(this._base._type == 'Sink') {
+                this._virtual = new VirtualPort(this._path, this._paDBus, this);
+                this._base.menu.addMenuItem(this._virtual);
+                this._base._updateExpandBtnVisiblity();
+                //log('Device', this._name, ', Virtual:', this._path);
+            }
+        }));
 
-		this._base.actor.connect('destroy', Lang.bind(this, this._onDestroy));
-	},
+        this._setOverdriveLevel();
+        this._sigOverdrive = this._settings.connect('changed::'+this._key_PA_OVERDRIVE, Lang.bind(this, this._setOverdriveLevel));
 
-	setActiveDevice: function(){
-		this._sigVol = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'VolumeUpdated',
-			this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onVolumeChanged), null );
-		this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Device', 'Volume']), 
-			GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
-			Lang.bind(this, function(conn, query){
-				let volV = conn.call_finish(query).get_child_value(0).unpack();
-				this.setVolume(volV);
-			})
-		);
+        this._base.actor.connect('destroy', Lang.bind(this, this._onDestroy));
+    },
 
-		this._sigMute = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'MuteUpdated',
-			this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onVolumeChanged), null );
-		this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Device', 'Mute']), 
-			GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
-			Lang.bind(this, function(conn, query){
-				let muteV = conn.call_finish(query).get_child_value(0).unpack();
-				this.setVolume(muteV);
-			})
-		);
+    _asyncDBusGetProperty: function(property, callback) {
+        this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Get',
+            GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Device', property]),
+            GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
+            Lang.bind(this, function(conn, query){
+                try{
+                    callback(conn, query);
+                } catch(err){
+                    //pulseaudio does something which creates, and then deletes a card when switching sources.  Therefore the listener will trigger this,
+                    //but by the time we can query anything from it, it's already gone.  Therefore ignore this exception.
+                    if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.UnknownMethod: Method \"Get\" with signature"))
+                        throw err;
+                }
+            })
+        );
+    },
 
-		if (this._numPorts > 0) {
-			this._sigPort = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'ActivePortUpdated',
-				this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onPortChanged), null );
-			this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Get',
-				GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Device', 'ActivePort']), 
-				GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
-				Lang.bind(this, function(conn, query){
-					let response = conn.call_finish(query).get_child_value(0).unpack();
-					let port = response.get_string()[0];
-					this.setActivePort(this._ports[port]);
-				})
-			);
-		} else if(this._virtual != null) {
-			this.setActivePort(this._virtual);
-		} else {
-			this.setDumbActivePort();
-		};
-		
+    setActiveDevice: function(){
+        this._sigVol = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'VolumeUpdated',
+            this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onVolumeChanged), null );
+        this._asyncDBusGetProperty('Volume', Lang.bind(this, function(conn, query){
+            let volV = conn.call_finish(query).get_child_value(0).unpack();
+            this.setVolume(volV);
+        }));
 
-		this._base.emit('fallback-updated', this._path);
-	},
+        this._sigMute = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'MuteUpdated',
+            this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onVolumeChanged), null );
+        this._asyncDBusGetProperty('Mute', Lang.bind(this, function(conn, query){
+            let muteV = conn.call_finish(query).get_child_value(0).unpack();
+            this.setVolume(muteV);
+        }));
 
-	setDumbActivePort: function(){
-		//Unset the currently active port
-		if(this._activePort != null)
-			this._activePort.setOrnament(PopupMenu.Ornament.NONE);
+        if (this._numPorts > 0) {
+            this._sigPort = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Device', 'ActivePortUpdated',
+                this._path, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onPortChanged), null );
+            this._asyncDBusGetProperty('ActivePort', Lang.bind(this, function(conn, query){
+                let response = conn.call_finish(query).get_child_value(0).unpack();
+                let port = response.get_string()[0];
+                this.setActivePort(this._ports[port]);
+            }));
+        } else if(this._virtual != null) {
+            this.setActivePort(this._virtual);
+        } else {
+            this.setDumbActivePort();
+        };
 
-		this._activePort = null;
 
-		this._base._nameLbl.set_text("");
-		this._base._setMuteIcon("");
-	},
+        this._base.emit('fallback-updated', this._path);
+    },
 
-	setActivePort: function(port){
-		//Unset the currently active port
-		if(this._activePort != null)
-			this._activePort.setOrnament(PopupMenu.Ornament.NONE);
+    setDumbActivePort: function(){
+        //Unset the currently active port
+        if(this._activePort != null)
+            this._activePort.setOrnament(PopupMenu.Ornament.NONE);
 
-		this._activePort = port;
-		this._activePort.setOrnament(PopupMenu.Ornament.DOT);
+        this._activePort = null;
 
-		port._giveName(Lang.bind(this, function(name, type){
-			this._base._nameLbl.set_text(name);
-			this._base._setMuteIcon(type);
-		}));
-	},
+        this._base._nameLbl.set_text("");
+        this._base._setMuteIcon("");
+    },
 
-	unsetActiveDevice: function(){
-		if(this._activePort != null) {
-			this._activePort.setOrnament(PopupMenu.Ornament.NONE);
-		};
-		this._activePort = null;
+    setActivePort: function(port){
+        //Unset the currently active port
+        if(this._activePort != null)
+            this._activePort.setOrnament(PopupMenu.Ornament.NONE);
 
-		this._paDBus.signal_unsubscribe(this._sigVol);
-		this._paDBus.signal_unsubscribe(this._sigMute);
-		if (this._numPorts > 0) {
-			this._paDBus.signal_unsubscribe(this._sigPort);
-		};
+        this._activePort = port;
+        this._activePort.setOrnament(PopupMenu.Ornament.DOT);
 
-		this._sigVol = this._sigMute = this._sigPort = 0;
-	},
+        port._giveName(Lang.bind(this, function(name, type){
+            this._base._nameLbl.set_text(name);
+            this._base._setMuteIcon(type);
+        }));
+    },
 
-	setVolume: function(volume){
-		this._base.emit('fallback-updated', this._path);
-		if(typeof volume === 'boolean'){
-			let val = GLib.Variant.new_boolean(volume);
-			this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Set',
-				GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Device', 'Mute', val]), null, 
-				Gio.DBusCallFlags.NONE, -1, null, null);
-		} 	
-		else if(typeof volume === 'number'){
-			if(volume > 1) volume = 1;
-			let max = this._volVariant.get_child_value(0).get_uint32();
-			for(let i = 1; i < this._volVariant.n_children(); i++){
-				let val = this._volVariant.get_child_value(i).get_uint32();
-				if(val > max) max = val;
-			}
+    unsetActiveDevice: function(){
+        if(this._activePort != null) {
+            this._activePort.setOrnament(PopupMenu.Ornament.NONE);
+        };
+        this._activePort = null;
 
-			let target = volume * this._getPAMaxPref();
-			if(target != max){ //Otherwise no change
-				let targets = new Array();
-				for(let i = 0; i < this._volVariant.n_children(); i++){
-					let newVal;
-					if(max == 0)
-						newVal = target;
-					else { //To maintain any balance the user has set.
-						let oldVal = this._volVariant.get_child_value(i).get_uint32();
-						newVal = (oldVal/max)*target;
-					}
-					newVal = Math.round(newVal);
-					targets[i] = GLib.Variant.new_uint32(newVal);
-				}
-				targets = GLib.Variant.new_array(null, targets);
-				this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Set',
-					GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Device', 'Volume', targets]), null, 
-					Gio.DBusCallFlags.NONE, -1, null, null);
-				if(this._muteVal)
-					this.setVolume(false);
-			}
-		}
-		else if(volume instanceof GLib.Variant){
-			let type = volume.get_type_string();
-			if(type == 'au'){
-				this._volVariant = volume;
-				if(!this._muteVal){
-					let maxVal = volume.get_child_value(0).get_uint32();
-					for(let i = 1; i < volume.n_children(); i++){
-						let val = volume.get_child_value(i).get_uint32();
-						if(val > maxVal) maxVal = val;
-					}
+        this._paDBus.signal_unsubscribe(this._sigVol);
+        this._paDBus.signal_unsubscribe(this._sigMute);
+        if (this._numPorts > 0) {
+            this._paDBus.signal_unsubscribe(this._sigPort);
+        };
 
-					this._base._slider.setValue(maxVal/this._getPAMaxPref());
-				}
-			}
-			else if(type == 'b'){
-				this._muteVal = volume.get_boolean();
-				if(this._muteVal)
-					this._base._slider.setValue(0);
-				else if(this._volVariant)
-					this.setVolume(this._volVariant);
-			}
+        this._sigVol = this._sigMute = this._sigPort = 0;
+    },
 
-			this._base.emit('icon-changed', this._base._slider.value);
-		}
-	},
+    setVolume: function(volume){
+        this._base.emit('fallback-updated', this._path);
+        if(typeof volume === 'boolean'){
+            let val = GLib.Variant.new_boolean(volume);
+            this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Set',
+                GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Device', 'Mute', val]), null,
+                Gio.DBusCallFlags.NONE, -1, null, null);
+        }
+        else if(typeof volume === 'number'){
+            if(volume > 1) volume = 1;
+            let max = this._volVariant.get_child_value(0).get_uint32();
+            for(let i = 1; i < this._volVariant.n_children(); i++){
+                let val = this._volVariant.get_child_value(i).get_uint32();
+                if(val > max) max = val;
+            }
 
-	_getPAMaxPref: function(){
-		return (PA_MAX * this._pa_overdrive)/100;
-	},
+            let target = volume * this._getPAMaxPref();
+            if(target != max){ //Otherwise no change
+                let targets = new Array();
+                for(let i = 0; i < this._volVariant.n_children(); i++){
+                    let newVal;
+                    if(max == 0)
+                        newVal = target;
+                    else { //To maintain any balance the user has set.
+                        let oldVal = this._volVariant.get_child_value(i).get_uint32();
+                        newVal = (oldVal/max)*target;
+                    }
+                    newVal = Math.round(newVal);
+                    targets[i] = GLib.Variant.new_uint32(newVal);
+                }
+                targets = GLib.Variant.new_array(null, targets);
+                this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Set',
+                    GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Device', 'Volume', targets]), null,
+                    Gio.DBusCallFlags.NONE, -1, null, null);
+                if(this._muteVal)
+                    this.setVolume(false);
+            }
+        }
+        else if(volume instanceof GLib.Variant){
+            let type = volume.get_type_string();
+            if(type == 'au'){
+                this._volVariant = volume;
+                if(!this._muteVal){
+                    let maxVal = volume.get_child_value(0).get_uint32();
+                    for(let i = 1; i < volume.n_children(); i++){
+                        let val = volume.get_child_value(i).get_uint32();
+                        if(val > maxVal) maxVal = val;
+                    }
 
-	_setOverdriveLevel: function(){
-		this._pa_overdrive = this._settings.get_int(this._key_PA_OVERDRIVE);
-	},
+                    this._base._slider.setValue(maxVal/this._getPAMaxPref());
+                }
+            }
+            else if(type == 'b'){
+                this._muteVal = volume.get_boolean();
+                if(this._muteVal)
+                    this._base._slider.setValue(0);
+                else if(this._volVariant)
+                    this.setVolume(this._volVariant);
+            }
 
-	//Event handlers
-	_onVolumeChanged: function(conn, sender, object, iface, signal, param, user_data){
-		if(signal == 'VolumeUpdated'){
-			let vals = param.get_child_value(0);
-			let startV = this._volVariant;
+            this._base.emit('icon-changed', this._base._slider.value);
+        }
+    },
 
-			let oldMax = startV.get_child_value(0).get_uint32();
-			let newMax = vals.get_child_value(0).get_uint32();
-			for(let i = 1; i < vals.n_children; i++){
-				let oVal = startV.get_child_value(i).get_uint32();
-				let nVal = vals[i].get_uint32();
+    _getPAMaxPref: function(){
+        return (PA_MAX * this._pa_overdrive)/100;
+    },
 
-				if(oVal > oldMax) oldMax = oVal;
-				if(nVal > newMax) newMax = nVal;
-			}
+    _setOverdriveLevel: function(){
+        this._pa_overdrive = this._settings.get_int(this._key_PA_OVERDRIVE);
+    },
 
-			if(oldMax != newMax){ //Otherwise there is no change
-				this._volVariant = vals;
-				this._base._slider.setValue(newMax / this._getPAMaxPref());
-			}
-		} 
-		else if(signal == 'MuteUpdated'){
-			this._muteVal = param.get_child_value(0).get_boolean();
+    //Event handlers
+    _onVolumeChanged: function(conn, sender, object, iface, signal, param, user_data){
+        if(signal == 'VolumeUpdated'){
+            let vals = param.get_child_value(0);
+            let startV = this._volVariant;
 
-			if(this._muteVal)
-				this._base._slider.setValue(0);
-			else {
-				let max = this._volVariant.get_child_value(0).get_uint32();
-				for(let i = 1; i < this._volVariant.n_children(); i++){
-					let val = this._volVariant.get_child_value(i).get_uint32();
-					if(max < val) max = val;
-				}
-				this._base._slider.setValue(max/this._getPAMaxPref());
-			}
-		}
-		this._base.emit('icon-changed', this._base._slider.value);
-	},
+            let oldMax = startV.get_child_value(0).get_uint32();
+            let newMax = vals.get_child_value(0).get_uint32();
+            for(let i = 1; i < vals.n_children; i++){
+                let oVal = startV.get_child_value(i).get_uint32();
+                let nVal = vals[i].get_uint32();
 
-	_onPortChanged: function(conn, sender, object, iface, signal, param, user_data){
-		let path = param.get_child_value(0).get_string()[0];
-		this.setActivePort(this._ports[path]);
-	},
+                if(oVal > oldMax) oldMax = oVal;
+                if(nVal > newMax) newMax = nVal;
+            }
 
-	_onPortSelect: function(port){
-		if (this._numPorts > 0 && this._activePort != port){
-			let value = GLib.Variant.new_object_path(port._path);
-			this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Set',
-				GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Device', 'ActivePort', value]), null, 
-				Gio.DBusCallFlags.NONE, -1, null, null);
-		}
+            if(oldMax != newMax){ //Otherwise there is no change
+                this._volVariant = vals;
+                this._base._slider.setValue(newMax / this._getPAMaxPref());
+            }
+        }
+        else if(signal == 'MuteUpdated'){
+            this._muteVal = param.get_child_value(0).get_boolean();
 
-		if(this._base._activeDevice != this){
-			let value = GLib.Variant.new_object_path(this._path);
-			this._paDBus.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Set',
-				GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1', 'Fallback'+this._base._type, value]), null, 
-				Gio.DBusCallFlags.NONE, -1, null, null);
-		}
-	},
+            if(this._muteVal)
+                this._base._slider.setValue(0);
+            else {
+                let max = this._volVariant.get_child_value(0).get_uint32();
+                for(let i = 1; i < this._volVariant.n_children(); i++){
+                    let val = this._volVariant.get_child_value(i).get_uint32();
+                    if(max < val) max = val;
+                }
+                this._base._slider.setValue(max/this._getPAMaxPref());
+            }
+        }
+        this._base.emit('icon-changed', this._base._slider.value);
+    },
 
-	_onDestroy: function(){
-		this._settings.disconnect(this._sigOverdrive);
-		if(this._sigVol != 0){
-			this._paDBus.signal_unsubscribe(this._sigVol);
-			this._paDBus.signal_unsubscribe(this._sigMute);
-			if (this._numPorts > 0) {
-				this._paDBus.signal_unsubscribe(this._sigPort);
-			};
-		}
-	},
+    _onPortChanged: function(conn, sender, object, iface, signal, param, user_data){
+        let path = param.get_child_value(0).get_string()[0];
+        this.setActivePort(this._ports[path]);
+    },
 
-	destroy: function(){
-		for(let p in this._ports) {
-			this._ports[p].destroy();
-		};
-		if (this._virtual != null) {
-			this._virtual.destroy();
-		};
-	}
+    _onPortSelect: function(port){
+        if (this._numPorts > 0 && this._activePort != port){
+            let value = GLib.Variant.new_object_path(port._path);
+            this._paDBus.call(null, this._path, 'org.freedesktop.DBus.Properties', 'Set',
+                GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Device', 'ActivePort', value]), null,
+                Gio.DBusCallFlags.NONE, -1, null, null);
+        }
+
+        if(this._base._activeDevice != this){
+            let value = GLib.Variant.new_object_path(this._path);
+            this._paDBus.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Set',
+                GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1', 'Fallback'+this._base._type, value]), null,
+                Gio.DBusCallFlags.NONE, -1, null, null);
+        }
+    },
+
+    _onDestroy: function(){
+        this._settings.disconnect(this._sigOverdrive);
+        if(this._sigVol != 0){
+            this._paDBus.signal_unsubscribe(this._sigVol);
+            this._paDBus.signal_unsubscribe(this._sigMute);
+            if (this._numPorts > 0) {
+                this._paDBus.signal_unsubscribe(this._sigPort);
+            };
+        }
+    },
+
+    destroy: function(){
+        for(let p in this._ports) {
+            this._ports[p].destroy();
+        };
+        if (this._virtual != null) {
+            this._virtual.destroy();
+        };
+    }
 });

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -1,7 +1,6 @@
 const Lang = imports.lang;
 const Gtk = imports.gi.Gtk;
 const GObject = imports.gi.GObject;
-const GLib = imports.gi.GLib;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -10,6 +10,7 @@ const _ = Gettext.gettext;
 const KEY_PA_OVER = "volume-overdrive";
 const KEY_PORT_LABEL = "show-port-label";
 const KEY_MERGE_CONTROLS = "merge-controls";
+const KEY_OPEN_SETTINGS = "open-settings";
 
 function init(){
 	Convenience.initTranslations();
@@ -40,11 +41,17 @@ const LainePrefsWidget = new GObject.Class({
 			label: _("Merge controls into aggregate menu"),
 			halign: Gtk.Align.END
 		});
+		let lbl_openSettings = new Gtk.Label({
+			label: _("Menu entry for external tool"),
+			halign: Gtk.Align.END
+		});
 
 		this.attach(lbl_volumeOverdrive, 0, 0, 1, 1);
 		this.attach_next_to(lbl_showPortLabel, lbl_volumeOverdrive,
 			Gtk.PositionType.BOTTOM, 1, 1);
 		this.attach_next_to(lbl_mergeAggregate, lbl_showPortLabel,
+			Gtk.PositionType.BOTTOM, 1, 1);
+		this.attach_next_to(lbl_openSettings, lbl_mergeAggregate,
 			Gtk.PositionType.BOTTOM, 1, 1);
 
 		//-----------------------------------------------------------
@@ -61,9 +68,9 @@ const LainePrefsWidget = new GObject.Class({
 		this._showLabelSwitch = new Gtk.Switch({
 			active: this._settings.get_boolean(KEY_PORT_LABEL)
 		});
-    this._showLabelSwitch.connect('notify::active', Lang.bind(this,
-			function(src){ this._settings.set_boolean(KEY_PORT_LABEL, src.active); }
-    ));
+        this._showLabelSwitch.connect('notify::active', Lang.bind(this,
+                function(src){ this._settings.set_boolean(KEY_PORT_LABEL, src.active); }
+        ));
 
 		this._mergeAggregateSwitch = new Gtk.Switch({
 			active: this._settings.get_boolean(KEY_MERGE_CONTROLS)
@@ -72,11 +79,20 @@ const LainePrefsWidget = new GObject.Class({
 			function(src){this._settings.set_boolean(KEY_MERGE_CONTROLS, src.active);}
 		));
 
+		this._openSettingsSwitch = new Gtk.Switch({
+			active: this._settings.get_boolean(KEY_OPEN_SETTINGS)
+		});
+		this._openSettingsSwitch.connect('notify::active', Lang.bind(this,
+			function(src){this._settings.set_boolean(KEY_OPEN_SETTINGS, src.active);}
+		));
+
 		this.attach_next_to(volumeOverdrive, lbl_volumeOverdrive,
 			Gtk.PositionType.RIGHT, 2, 1);
 		this.attach_next_to(this._showLabelSwitch, lbl_showPortLabel,
 			Gtk.PositionType.RIGHT, 1, 1);
 		this.attach_next_to(this._mergeAggregateSwitch, lbl_mergeAggregate,
+			Gtk.PositionType.RIGHT, 1, 1);
+		this.attach_next_to(this._openSettingsSwitch, lbl_openSettings,
 			Gtk.PositionType.RIGHT, 1, 1);
 		volumeOverdrive.set_hexpand(true);
 		volumeOverdrive.add_mark(100, Gtk.PositionType.BOTTOM, null);

--- a/src/schemas/org.gnome.shell.extensions.laine.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.laine.gschema.xml
@@ -23,5 +23,12 @@
 				Show controls as part of aggregate menu instead of in seperate dropdown.
 			</description>
 		</key>
+		<key type="b" name="open-settings">
+			<default>true</default>
+			<summary>Menu entry for external tool</summary>
+			<description>
+				Add a menu entry to open an external audio control tool, like pavucontrol
+			</description>
+		</key>
 	</schema>
 </schemalist>

--- a/src/schemas/org.gnome.shell.extensions.laine.gschema.xml
+++ b/src/schemas/org.gnome.shell.extensions.laine.gschema.xml
@@ -25,9 +25,16 @@
 		</key>
 		<key type="b" name="open-settings">
 			<default>true</default>
-			<summary>Menu entry for external tool</summary>
+			<summary>Menu entry for configuration tool</summary>
 			<description>
-				Add a menu entry to open an external audio control tool, like pavucontrol
+				Add a menu entry to open a configuration tool for pulseaudio, like pavucontrol
+			</description>
+		</key>
+		<key type="s" name="app-settings">
+			<default>'pavucontrol'</default>
+			<summary>Configuration tool to open</summary>
+			<description>
+				The application to configura pulseaudio to open, default to pavucontrol.
 			</description>
 		</key>
 	</schema>

--- a/src/sinkMenu.js
+++ b/src/sinkMenu.js
@@ -26,6 +26,8 @@ const SinkMenu = new Lang.Class({
 			this._icon.icon_name = 'audio-headphones-symbolic';
 		else if(desc.startsWith("hdmi") || desc.startsWith("iec958"))
 			this._icon.icon_name = 'audio-card-symbolic';
+		else if(desc.endsWith("virtual"))
+			this._icon.icon_name = 'audio-x-generic-symbolic';
 		else
 			this._icon.icon_name = 'audio-speakers-symbolic';
 	},

--- a/src/sourceMenu.js
+++ b/src/sourceMenu.js
@@ -60,11 +60,11 @@ const SourceMenu = new Lang.Class({
 	},
 
 	_onAddStream: function(conn, sender, object, iface, signal, param, user_data) {
-        let path = param.get_child_value(0).unpack();
-        this._addStream(path);
-    },
-    
-    _onRemoveStream: function(conn, sender, object, iface, signal, param, user_data) {
+		let path = param.get_child_value(0).unpack();
+		this._addStream(path);
+	},
+	
+	_onRemoveStream: function(conn, sender, object, iface, signal, param, user_data) {
 		let path = param.get_child_value(0).unpack();
 		let index = this._streams.indexOf(path);
 		if(index != -1){
@@ -78,7 +78,7 @@ const SourceMenu = new Lang.Class({
 		if(desc.endsWith("-mic"))
 			this._icon.icon_name = 'audio-headset-symbolic';
 		else
-            this._icon.icon_name = 'audio-input-microphone-symbolic';
+			this._icon.icon_name = 'audio-input-microphone-symbolic';
 	},
 
 	_isExpandBtnVisible: function(){

--- a/src/sourceMenu.js
+++ b/src/sourceMenu.js
@@ -75,7 +75,10 @@ const SourceMenu = new Lang.Class({
 
 
 	_setMuteIcon: function(desc){
-		this._icon.icon_name = 'audio-input-microphone-symbolic';
+		if(desc.endsWith("-mic"))
+			this._icon.icon_name = 'audio-headset-symbolic';
+		else
+            this._icon.icon_name = 'audio-input-microphone-symbolic';
 	},
 
 	_isExpandBtnVisible: function(){

--- a/src/sourceMenu.js
+++ b/src/sourceMenu.js
@@ -35,11 +35,8 @@ const SourceMenu = new Lang.Class({
 		this._updateVisibility();
 
 		this._sigNewStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'NewRecordStream',
-			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, function(conn, sender, object, iface, signal, param, user_data){
-				let streamPath = param.get_child_value(0).unpack();
-				this._addStream(streamPath);
-			}), null );
-		this._sigNewStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'RecordStreamRemoved',
+			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onAddStream), null );
+		this._sigRemStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'RecordStreamRemoved',
 			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onRemoveStream), null );
 
 		this.connect('fallback-updated', Lang.bind(this, this._onSetDefaultSource));
@@ -62,14 +59,18 @@ const SourceMenu = new Lang.Class({
 		);
 	},
 
-	_onRemoveStream: function(conn, sender, object, iface, signal, param, user_data) {
+	_onAddStream: function(conn, sender, object, iface, signal, param, user_data) {
+        let path = param.get_child_value(0).unpack();
+        this._addStream(path);
+    },
+    
+    _onRemoveStream: function(conn, sender, object, iface, signal, param, user_data) {
 		let path = param.get_child_value(0).unpack();
 		let index = this._streams.indexOf(path);
 		if(index != -1){
 			this._streams.splice(index, 1);
 			this._updateVisibility();
-		}
-
+		};
 	},
 
 

--- a/src/sourceMenu.js
+++ b/src/sourceMenu.js
@@ -35,9 +35,9 @@ const SourceMenu = new Lang.Class({
 		this._updateVisibility();
 
 		this._sigNewStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'NewRecordStream',
-			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onAddStream), null );
+			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onAddStream));
 		this._sigRemStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'RecordStreamRemoved',
-			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onRemoveStream), null );
+			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onRemoveStream));
 
 		this.connect('fallback-updated', Lang.bind(this, this._onSetDefaultSource));
 		this.actor.connect('destroy', Lang.bind(this, this._onSubDestroy));

--- a/src/streamMenu.js
+++ b/src/streamMenu.js
@@ -21,1107 +21,1107 @@ const Convenience = Me.imports.convenience;
 
 const PA_MAX = 65536;
 const WATCH_RULE = "type='signal'," +
-		"sender='org.freedesktop.DBus'," +
-		"interface='org.freedesktop.DBus'," +
-		"member='NameOwnerChanged'," +
-		"path='/org/freedesktop/DBus'," +
-		"arg0namespace='org.mpris.MediaPlayer2'";
+        "sender='org.freedesktop.DBus'," +
+        "interface='org.freedesktop.DBus'," +
+        "member='NameOwnerChanged'," +
+        "path='/org/freedesktop/DBus'," +
+        "arg0namespace='org.mpris.MediaPlayer2'";
 
 const StreamMenu = new Lang.Class({
-	Name: 'StreamMenu',
-	Extends: PopupMenu.PopupMenuSection,
+    Name: 'StreamMenu',
+    Extends: PopupMenu.PopupMenuSection,
 
-	_init: function(parent, paconn){
-		this.parent();
-		this.actor.add_style_class_name('stream_container');
-		this._paDBus = paconn;
-		this._parent = parent;
+    _init: function(parent, paconn){
+        this.parent();
+        this.actor.add_style_class_name('stream_container');
+        this._paDBus = paconn;
+        this._parent = parent;
 
-		this._mprisControl = new MPRISControl(this, this._paDBus);
+        this._mprisControl = new MPRISControl(this, this._paDBus);
 
-		this._streams = {};
-		this._delegatedStreams = {};
+        this._streams = {};
+        this._delegatedStreams = {};
 
-		//Add any existing streams
-		if(!(this._mprisControl))
-			this._addExistingStreams();
+        //Add any existing streams
+        if(!(this._mprisControl))
+            this._addExistingStreams();
 
-		//Add signal handlers
-		this._sigNewStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'NewPlaybackStream',
-			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onAddStream), null );
-		this._sigRemStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'PlaybackStreamRemoved',
-			'/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onRemoveStream), null );
+        //Add signal handlers
+        this._sigNewStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'NewPlaybackStream',
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onAddStream), null );
+        this._sigRemStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'PlaybackStreamRemoved',
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onRemoveStream), null );
 
-		this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
-	},
+        this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
+    },
 
-	_addExistingStreams: function(){
-		this._paDBus.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1', 'PlaybackStreams']),
-			GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
-			Lang.bind(this, function(conn, query){
-				let response = conn.call_finish(query).get_child_value(0).unpack();
-				for(let i = 0; i < response.n_children(); i++)
-					this._addPAStream(response.get_child_value(i).get_string()[0]);
-			})
-		);
-	},
+    _addExistingStreams: function(){
+        this._paDBus.call(null, '/org/pulseaudio/core1', 'org.freedesktop.DBus.Properties', 'Get',
+            GLib.Variant.new('(ss)', ['org.PulseAudio.Core1', 'PlaybackStreams']),
+            GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null,
+            Lang.bind(this, function(conn, query){
+                let response = conn.call_finish(query).get_child_value(0).unpack();
+                for(let i = 0; i < response.n_children(); i++)
+                    this._addPAStream(response.get_child_value(i).get_string()[0]);
+            })
+        );
+    },
 
-	_addPAStream: function(path){
-		this._paDBus.call(null, path, 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Stream', 'PropertyList']),
-			GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				let streamInfo = conn.call_finish(query).get_child_value(0).unpack();
+    _addPAStream: function(path){
+        this._paDBus.call(null, path, 'org.freedesktop.DBus.Properties', 'Get',
+            GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Stream', 'PropertyList']),
+            GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                let streamInfo = conn.call_finish(query).get_child_value(0).unpack();
 
-				//Decode stream information
-				let sInfo = {};
-				for(let i = 0; i < streamInfo.n_children(); i++){
-					let [key, value] = streamInfo.get_child_value(i).unpack();
-					let bytes = new Array();
-					for(let j = 0; j < value.n_children(); j++)
-						bytes[j] = value.get_child_value(j).get_byte();
-					sInfo[key.get_string()[0]] = String.fromCharCode.apply(String, bytes);
-				}
+                //Decode stream information
+                let sInfo = {};
+                for(let i = 0; i < streamInfo.n_children(); i++){
+                    let [key, value] = streamInfo.get_child_value(i).unpack();
+                    let bytes = new Array();
+                    for(let j = 0; j < value.n_children(); j++)
+                        bytes[j] = value.get_child_value(j).get_byte();
+                    sInfo[key.get_string()[0]] = String.fromCharCode.apply(String, bytes);
+                }
 
-				let pID = parseInt(sInfo['application.process.id']);
-				let role;
-				if('media.role' in sInfo){
-					role = sInfo['media.role'];
-					role = role.substring(0, role.length -1);
-				}
+                let pID = parseInt(sInfo['application.process.id']);
+                let role;
+                if('media.role' in sInfo){
+                    role = sInfo['media.role'];
+                    role = role.substring(0, role.length -1);
+                }
 
-				this._moveStreamToDefaultSink(path);
+                this._moveStreamToDefaultSink(path);
 
-				if(role != 'event'){
-					let mprisCheck = false;
+                if(role != 'event'){
+                    let mprisCheck = false;
 
-					if(this._mprisControl){
-						mprisCheck = this._mprisControl.isMPRISStream(pID, path);
-					}
+                    if(this._mprisControl){
+                        mprisCheck = this._mprisControl.isMPRISStream(pID, path);
+                    }
 
-					if(mprisCheck){
-						this._delegatedStreams[path] = this._mprisControl._mprisStreams[pID];
-					} else {
-						let stream = new SimpleStream(this, this._paDBus, path, sInfo);
-						this._streams[path] = stream;
-						this.addMenuItem(stream);
-					}
-				}
-			})
-		);
-	},
+                    if(mprisCheck){
+                        this._delegatedStreams[path] = this._mprisControl._mprisStreams[pID];
+                    } else {
+                        let stream = new SimpleStream(this, this._paDBus, path, sInfo);
+                        this._streams[path] = stream;
+                        this.addMenuItem(stream);
+                    }
+                }
+            })
+        );
+    },
 
-	_moveStreamToDefaultSink: function(path) {
-		this._paDBus.call(null, path, 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Stream', 'Device']), GLib.VariantType.new('(v)'),
-			Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				let resp = conn.call_finish(query);
-				resp = resp.get_child_value(0).unpack();
+    _moveStreamToDefaultSink: function(path) {
+        this._paDBus.call(null, path, 'org.freedesktop.DBus.Properties', 'Get',
+            GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Stream', 'Device']), GLib.VariantType.new('(v)'),
+            Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                let resp = conn.call_finish(query);
+                resp = resp.get_child_value(0).unpack();
 
-				let cPath = resp.get_string()[0];
-				if(cPath != path)
-					this._paDBus.call(null, path, 'org.PulseAudio.Core1.Stream', 'Move',
-						GLib.Variant.new('(o)', [this._defaultSink]), null, Gio.DBusCallFlags.NONE, -1, null, null);
-			})
-		);
-	},
+                let cPath = resp.get_string()[0];
+                if(cPath != path)
+                    this._paDBus.call(null, path, 'org.PulseAudio.Core1.Stream', 'Move',
+                        GLib.Variant.new('(o)', [this._defaultSink]), null, Gio.DBusCallFlags.NONE, -1, null, null);
+            })
+        );
+    },
 
-	_getTopMenu: function(){
-		return this._parent._getTopMenu();
-	},
+    _getTopMenu: function(){
+        return this._parent._getTopMenu();
+    },
 
-	_onSetDefaultSink: function(src, sink){
-		this._defaultSink = sink;
+    _onSetDefaultSink: function(src, sink){
+        this._defaultSink = sink;
 
-		for(let k in this._streams)
-				this._moveStreamToDefaultSink(k);
+        for(let k in this._streams)
+                this._moveStreamToDefaultSink(k);
 
-		for(let k in this._delegatedStreams){
-				let obj = this._delegatedStreams[k]._paPath;
-				this._moveStreamToDefaultSink(obj);
-		}
-	},
+        for(let k in this._delegatedStreams){
+                let obj = this._delegatedStreams[k]._paPath;
+                this._moveStreamToDefaultSink(obj);
+        }
+    },
 
-	_onAddStream: function(conn, sender, object, iface, signal, param, user_data){
-		let streamPath = param.get_child_value(0).unpack();
-		this._addPAStream(streamPath);
-		this.actor.remove_style_pseudo_class('empty');
-	},
+    _onAddStream: function(conn, sender, object, iface, signal, param, user_data){
+        let streamPath = param.get_child_value(0).unpack();
+        this._addPAStream(streamPath);
+        this.actor.remove_style_pseudo_class('empty');
+    },
 
-	_onRemoveStream: function(conn, sender, object, iface, signal, param, user_data){
+    _onRemoveStream: function(conn, sender, object, iface, signal, param, user_data){
 
-		let streamPath = param.get_child_value(0).unpack();
+        let streamPath = param.get_child_value(0).unpack();
 
-		if(streamPath in this._streams){
-			this._streams[streamPath].destroy();
-			delete this._streams[streamPath];
-			this.actor.queue_relayout();
-		}
-		else if(streamPath in this._delegatedStreams){
-			this._mprisControl.removePAStream(streamPath);
-			delete this._delegatedStreams[streamPath];
-			this.actor.queue_relayout();
-		}
+        if(streamPath in this._streams){
+            this._streams[streamPath].destroy();
+            delete this._streams[streamPath];
+            this.actor.queue_relayout();
+        }
+        else if(streamPath in this._delegatedStreams){
+            this._mprisControl.removePAStream(streamPath);
+            delete this._delegatedStreams[streamPath];
+            this.actor.queue_relayout();
+        }
 
-		if(Object.keys(this._streams).length == 0 &&
-			Object.keys(this._delegatedStreams).length == 0)
-			this.actor.add_style_pseudo_class('empty');
-	},
+        if(Object.keys(this._streams).length == 0 &&
+            Object.keys(this._delegatedStreams).length == 0)
+            this.actor.add_style_pseudo_class('empty');
+    },
 
-	_onDestroy: function(){
-		this._paDBus.signal_unsubscribe(this._sigNewStr);
-		this._paDBus.signal_unsubscribe(this._sigRemStr);
-	}
+    _onDestroy: function(){
+        this._paDBus.signal_unsubscribe(this._sigNewStr);
+        this._paDBus.signal_unsubscribe(this._sigRemStr);
+    }
 });
 
 
 const StreamBase = new Lang.Class({
-	Name: 'StreamBase',
-	Extends: PopupMenu.PopupMenuSection,
-	Abstract: true,
+    Name: 'StreamBase',
+    Extends: PopupMenu.PopupMenuSection,
+    Abstract: true,
 
-	_init: function(parent, paconn){
-		this.parent();
-		this._paDBus = paconn;
-		this._paPath = null;
-		this._parent = parent;
+    _init: function(parent, paconn){
+        this.parent();
+        this._paDBus = paconn;
+        this._paPath = null;
+        this._parent = parent;
 
-		this._label = new St.Label({style_class: 'simple-stream-label',
-			reactive: true, track_hover:true});
-		this._muteBtn = new St.Button();
-		this._volSlider = new Slider.Slider(0);
+        this._label = new St.Label({style_class: 'simple-stream-label',
+            reactive: true, track_hover:true});
+        this._muteBtn = new St.Button();
+        this._volSlider = new Slider.Slider(0);
 
-		//------------------------------------------------------------------
-		//Laying out components
-		let container = new St.BoxLayout({vertical:true});
-		container.add(this._label);
-		container.add(this._volSlider.actor,{expand:true});
+        //------------------------------------------------------------------
+        //Laying out components
+        let container = new St.BoxLayout({vertical:true});
+        container.add(this._label);
+        container.add(this._volSlider.actor,{expand:true});
 
-		this._volCtrl = new St.BoxLayout();
-		this._volCtrl.add(this._muteBtn);
-		this._volCtrl.add(container, {expand:true});
-		this._volCtrl.add_style_class_name('stream');
+        this._volCtrl = new St.BoxLayout();
+        this._volCtrl.add(this._muteBtn);
+        this._volCtrl.add(container, {expand:true});
+        this._volCtrl.add_style_class_name('stream');
 
-		this.actor.set_vertical(false);
-		this.actor.set_track_hover(true);
-		this.actor.set_reactive(true);
-		this.focused = false;
+        this.actor.set_vertical(false);
+        this.actor.set_track_hover(true);
+        this.actor.set_reactive(true);
+        this.focused = false;
 
-		this.actor.add(this._volCtrl, {expand:true});
+        this.actor.add(this._volCtrl, {expand:true});
 
-		//------------------------------------------------------------------
+        //------------------------------------------------------------------
 
-		this._muteBtn.connect('clicked', Lang.bind(this, function(){
-			this.setVolume(!this._muteVal);
-		}));
+        this._muteBtn.connect('clicked', Lang.bind(this, function(){
+            this.setVolume(!this._muteVal);
+        }));
 
-		this._volSlider.connect('value-changed', Lang.bind(this, function(slider, value, property){
-			this.setVolume(value);
-		}));
+        this._volSlider.connect('value-changed', Lang.bind(this, function(slider, value, property){
+            this.setVolume(value);
+        }));
 
-		this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
-	},
+        this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
+    },
 
-	setPAPath: function(path){
-		this._paPath = path;
+    setPAPath: function(path){
+        this._paPath = path;
 
-		this._paDBus.call(null, this._paPath, 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Stream', 'Mute']), GLib.VariantType.new("(v)"),
-			Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				let result = conn.call_finish(query);
-				this.setVolume(result.get_child_value(0).unpack());
-			}));
+        this._paDBus.call(null, this._paPath, 'org.freedesktop.DBus.Properties', 'Get',
+            GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Stream', 'Mute']), GLib.VariantType.new("(v)"),
+            Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                let result = conn.call_finish(query);
+                this.setVolume(result.get_child_value(0).unpack());
+            }));
 
-		this._paDBus.call(null, this._paPath, 'org.freedesktop.DBus.Properties', 'Get',
-			GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Stream', 'Volume']), GLib.VariantType.new("(v)"),
-			Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				let result = conn.call_finish(query);
-				this.setVolume(result.get_child_value(0).unpack());
-			}));
+        this._paDBus.call(null, this._paPath, 'org.freedesktop.DBus.Properties', 'Get',
+            GLib.Variant.new('(ss)', ['org.PulseAudio.Core1.Stream', 'Volume']), GLib.VariantType.new("(v)"),
+            Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                let result = conn.call_finish(query);
+                this.setVolume(result.get_child_value(0).unpack());
+            }));
 
-		this._sigVol = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Stream', 'VolumeUpdated',
-			this._paPath, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, function(conn, sender, object, iface, signal, param, user_data){
-				this.setVolume(param.get_child_value(0));
-			}), null );
-		this._sigMute = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Stream', 'MuteUpdated',
-			this._paPath, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, function(conn, sender, object, iface, signal, param, user_data){
-				this.setVolume(param.get_child_value(0));
-			}), null );
-	},
+        this._sigVol = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Stream', 'VolumeUpdated',
+            this._paPath, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, function(conn, sender, object, iface, signal, param, user_data){
+                this.setVolume(param.get_child_value(0));
+            }), null );
+        this._sigMute = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Stream', 'MuteUpdated',
+            this._paPath, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, function(conn, sender, object, iface, signal, param, user_data){
+                this.setVolume(param.get_child_value(0));
+            }), null );
+    },
 
-	setVolume: function(volume){
-		if(typeof volume === 'boolean' && this._paPath != null){
-			let val = GLib.Variant.new_boolean(volume);
-			this._paDBus.call(null, this._paPath, 'org.freedesktop.DBus.Properties', 'Set',
-				GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Stream', 'Mute', val]), null,
-				Gio.DBusCallFlags.NONE, -1, null, null);
-		}
-		else if(typeof volume === 'number' && this._paPath != null){
-			if(volume > 1) volume = 1;
-			let max = this._volVariant.get_child_value(0).get_uint32();
-			for(let i = 1; i < this._volVariant.n_children(); i++){
-				let val = this._volVariant.get_child_value(i).get_uint32();
-				if(val > max) max = val;
-			}
+    setVolume: function(volume){
+        if(typeof volume === 'boolean' && this._paPath != null){
+            let val = GLib.Variant.new_boolean(volume);
+            this._paDBus.call(null, this._paPath, 'org.freedesktop.DBus.Properties', 'Set',
+                GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Stream', 'Mute', val]), null,
+                Gio.DBusCallFlags.NONE, -1, null, null);
+        }
+        else if(typeof volume === 'number' && this._paPath != null){
+            if(volume > 1) volume = 1;
+            let max = this._volVariant.get_child_value(0).get_uint32();
+            for(let i = 1; i < this._volVariant.n_children(); i++){
+                let val = this._volVariant.get_child_value(i).get_uint32();
+                if(val > max) max = val;
+            }
 
-			let target = volume * PA_MAX;
-			if(target != max){ //Otherwise no change
-				let targets = new Array();
-				for(let i = 0; i < this._volVariant.n_children(); i++){
-					let newVal;
-					if(max == 0)
-						newVal = target;
-					else { //To maintain any balance the user has set.
-						let oldVal = this._volVariant.get_child_value(i).get_uint32();
-						newVal = (oldVal/max)*target;
-					}
-					newVal = Math.round(newVal);
-					targets[i] = GLib.Variant.new_uint32(newVal);
-				}
-				targets = GLib.Variant.new_array(null, targets);
-				this._paDBus.call(null, this._paPath, 'org.freedesktop.DBus.Properties', 'Set',
-					GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Stream', 'Volume', targets]), null,
-					Gio.DBusCallFlags.NONE, -1, null, null);
-				if(this._muteVal)
-					this.setVolume(false);
-			}
-		}
-		else if(volume instanceof GLib.Variant){
-			let type = volume.get_type_string();
-			if(type == 'au'){
-				this._volVariant = volume;
-				if(!this._muteVal){
-					let maxVal = volume.get_child_value(0).get_uint32();
-					for(let i = 1; i < volume.n_children(); i++){
-						let val = volume.get_child_value(i).get_uint32();
-						if(val > maxVal) maxVal = val;
-					}
+            let target = volume * PA_MAX;
+            if(target != max){ //Otherwise no change
+                let targets = new Array();
+                for(let i = 0; i < this._volVariant.n_children(); i++){
+                    let newVal;
+                    if(max == 0)
+                        newVal = target;
+                    else { //To maintain any balance the user has set.
+                        let oldVal = this._volVariant.get_child_value(i).get_uint32();
+                        newVal = (oldVal/max)*target;
+                    }
+                    newVal = Math.round(newVal);
+                    targets[i] = GLib.Variant.new_uint32(newVal);
+                }
+                targets = GLib.Variant.new_array(null, targets);
+                this._paDBus.call(null, this._paPath, 'org.freedesktop.DBus.Properties', 'Set',
+                    GLib.Variant.new('(ssv)', ['org.PulseAudio.Core1.Stream', 'Volume', targets]), null,
+                    Gio.DBusCallFlags.NONE, -1, null, null);
+                if(this._muteVal)
+                    this.setVolume(false);
+            }
+        }
+        else if(volume instanceof GLib.Variant){
+            let type = volume.get_type_string();
+            if(type == 'au'){
+                this._volVariant = volume;
+                if(!this._muteVal){
+                    let maxVal = volume.get_child_value(0).get_uint32();
+                    for(let i = 1; i < volume.n_children(); i++){
+                        let val = volume.get_child_value(i).get_uint32();
+                        if(val > maxVal) maxVal = val;
+                    }
 
-					this._volSlider.setValue(maxVal/PA_MAX);
-				}
-			}
-			else if(type == 'b'){
-				this._muteVal = volume.get_boolean();
-				if(this._muteVal)
-					this._volSlider.setValue(0);
-				else if(this._volVariant)
-					this.setVolume(this._volVariant);
-			}
-		}
-	},
+                    this._volSlider.setValue(maxVal/PA_MAX);
+                }
+            }
+            else if(type == 'b'){
+                this._muteVal = volume.get_boolean();
+                if(this._muteVal)
+                    this._volSlider.setValue(0);
+                else if(this._volVariant)
+                    this.setVolume(this._volVariant);
+            }
+        }
+    },
 
-	_setFocused: function(activate){
-		let focusChanged = activate != this.focused;
-		if(focusChanged){
-			this.focused = activate;
-			if(activate){
-				this.actor.add_style_pseudo_class('active');
-				this.actor.grab_key_focus();
-			} else {
-				this.actor.remove_style_pseudo_class('active');
-			}
+    _setFocused: function(activate){
+        let focusChanged = activate != this.focused;
+        if(focusChanged){
+            this.focused = activate;
+            if(activate){
+                this.actor.add_style_pseudo_class('active');
+                this.actor.grab_key_focus();
+            } else {
+                this.actor.remove_style_pseudo_class('active');
+            }
 
-		}
-	},
+        }
+    },
 
-	_onDestroy: function(){
-		if(this._paPath != null){
-			this._paDBus.signal_unsubscribe(this._sigVol);
-			this._paDBus.signal_unsubscribe(this._sigMute);
-		}
-	},
+    _onDestroy: function(){
+        if(this._paPath != null){
+            this._paDBus.signal_unsubscribe(this._sigVol);
+            this._paDBus.signal_unsubscribe(this._sigMute);
+        }
+    },
 
-	_raise: function(){}
+    _raise: function(){}
 
 });
 
 const SimpleStream = new Lang.Class({
-	Name: 'SimpleStream',
-	Extends: StreamBase,
+    Name: 'SimpleStream',
+    Extends: StreamBase,
 
-	_init: function(parent, paconn, path, sInfo){
-		this.parent(parent, paconn);
-		this.setPAPath(path);
+    _init: function(parent, paconn, path, sInfo){
+        this.parent(parent, paconn);
+        this.setPAPath(path);
 
-		this.actor.add_style_class_name('simple-stream');
+        this.actor.add_style_class_name('simple-stream');
 
-		this._procID = parseInt(sInfo['application.process.id']);
+        this._procID = parseInt(sInfo['application.process.id']);
 
-		this._app = WindowTracker.get_app_from_pid(this._procID);
-		if(this._app == null){
-			//Doesn't have an open window, lets check the tray.
-			let trayNotifications = Main.messageTray.getSources();
-			for(let i = 0; i < trayNotifications.length; i++)
-				if(trayNotifications[i].pid == this._procID)
-					this._app = trayNotifications[i].app;
-		}
+        this._app = WindowTracker.get_app_from_pid(this._procID);
+        if(this._app == null){
+            //Doesn't have an open window, lets check the tray.
+            let trayNotifications = Main.messageTray.getSources();
+            for(let i = 0; i < trayNotifications.length; i++)
+                if(trayNotifications[i].pid == this._procID)
+                    this._app = trayNotifications[i].app;
+        }
 
-		let icon, name= null;
-		if(this._app != null){
-			let info = this._app.get_app_info();
-			if(info != null){
-				name = info.get_name();
-				icon = new St.Icon({style_class: 'icon'});
-				icon.set_gicon(info.get_icon());
-			}
-			this._label.add_style_pseudo_class('clickable');
-		}
+        let icon, name= null;
+        if(this._app != null){
+            let info = this._app.get_app_info();
+            if(info != null){
+                name = info.get_name();
+                icon = new St.Icon({style_class: 'icon'});
+                icon.set_gicon(info.get_icon());
+            }
+            this._label.add_style_pseudo_class('clickable');
+        }
 
-		if(name == null){
-			name = sInfo['application.name'];
-			let iname;
-			if('application.icon_name' in sInfo) iname = sInfo['application.icon_name'];
-			else iname = 'package_multimedia';
-			icon = new St.Icon({icon_name: iname, style_class: 'simple-stream-icon'});
-		}
+        if(name == null){
+            name = sInfo['application.name'];
+            let iname;
+            if('application.icon_name' in sInfo) iname = sInfo['application.icon_name'];
+            else iname = 'package_multimedia';
+            icon = new St.Icon({icon_name: iname, style_class: 'simple-stream-icon'});
+        }
 
-		this._muteBtn.child = icon;
-		this._label.text = name;
+        this._muteBtn.child = icon;
+        this._label.text = name;
 
-		this._label.connect('button-press-event', Lang.bind(this, function(){
-			if(this._app != null){
-				this._app.activate();
-				this._parent._getTopMenu().close(BoxPointer.PopupAnimation.FULL);
-			}
-		}));
+        this._label.connect('button-press-event', Lang.bind(this, function(){
+            if(this._app != null){
+                this._app.activate();
+                this._parent._getTopMenu().close(BoxPointer.PopupAnimation.FULL);
+            }
+        }));
 
-		this.actor.connect('key-press-event', Lang.bind(this, this._onKeyPressEvent));
+        this.actor.connect('key-press-event', Lang.bind(this, this._onKeyPressEvent));
 
-		this.actor.can_focus = true;
-		this.actor.connect('notify::hover', Lang.bind(this, function(){this._setFocused(this.actor.hover);}));
-		this.actor.connect('key-focus-in', Lang.bind(this, function(){this._setFocused(true);}));
-		this.actor.connect('key-focus-out', Lang.bind(this, function(){this._setFocused(false)}));
-		this.actor.connect('scroll-event', Lang.bind(this._volSlider, this._volSlider._onScrollEvent));
-	},
+        this.actor.can_focus = true;
+        this.actor.connect('notify::hover', Lang.bind(this, function(){this._setFocused(this.actor.hover);}));
+        this.actor.connect('key-focus-in', Lang.bind(this, function(){this._setFocused(true);}));
+        this.actor.connect('key-focus-out', Lang.bind(this, function(){this._setFocused(false)}));
+        this.actor.connect('scroll-event', Lang.bind(this._volSlider, this._volSlider._onScrollEvent));
+    },
 
-	_onKeyPressEvent: function(actor, event) {
-		let key = event.get_key_symbol();
+    _onKeyPressEvent: function(actor, event) {
+        let key = event.get_key_symbol();
 
-		if(key == Clutter.KEY_Right || key == Clutter.KEY_Left){
-			this._volSlider.onKeyPressEvent(actor, event);
-			return Clutter.EVENT_STOP;
-		}
-		else if(key == Clutter.KEY_space || key == Clutter.KEY_Return) {
-			this.setVolume(!this._muteVal);
-			return Clutter.EVENT_STOP;
-		}
+        if(key == Clutter.KEY_Right || key == Clutter.KEY_Left){
+            this._volSlider.onKeyPressEvent(actor, event);
+            return Clutter.EVENT_STOP;
+        }
+        else if(key == Clutter.KEY_space || key == Clutter.KEY_Return) {
+            this.setVolume(!this._muteVal);
+            return Clutter.EVENT_STOP;
+        }
 
-		return Clutter.EVENT_PROPAGATE;
-	}
+        return Clutter.EVENT_PROPAGATE;
+    }
 
 
 });
 
 const MPRISControl = new Lang.Class({
-	Name: 'MPRISControl',
+    Name: 'MPRISControl',
 
-	_init: function(parent, paconn){
-		this._parent = parent;
-		this._paDBus = paconn
-		this.actor = parent.actor;
+    _init: function(parent, paconn){
+        this._parent = parent;
+        this._paDBus = paconn
+        this.actor = parent.actor;
 
-		this._mprisStreams = {};
+        this._mprisStreams = {};
 
-		Gio.bus_get(Gio.BusType.SESSION, null, Lang.bind(this, this._hdlBusConnection));
+        Gio.bus_get(Gio.BusType.SESSION, null, Lang.bind(this, this._hdlBusConnection));
 
-		this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
-	},
+        this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
+    },
 
-	_hdlBusConnection: function(conn, query){
-		this._dbus = Gio.bus_get_finish(query);
-		this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "ListNames",
-			null, GLib.VariantType.new("(as)"), Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, this._hdlListNames));
+    _hdlBusConnection: function(conn, query){
+        this._dbus = Gio.bus_get_finish(query);
+        this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "ListNames",
+            null, GLib.VariantType.new("(as)"), Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, this._hdlListNames));
 
-		this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "AddMatch",
-			GLib.Variant.new('(s)', [WATCH_RULE]), null, Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(){
-				this._sigNOC = this._dbus.signal_subscribe('org.freedesktop.DBus', "org.freedesktop.DBus", "NameOwnerChanged",
-    				"/org/freedesktop/DBus", null, Gio.DBusSignalFlags.NO_MATCH_RULE, Lang.bind(this, this._onConnChange));
-			}));
-	},
+        this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "AddMatch",
+            GLib.Variant.new('(s)', [WATCH_RULE]), null, Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(){
+                this._sigNOC = this._dbus.signal_subscribe('org.freedesktop.DBus', "org.freedesktop.DBus", "NameOwnerChanged",
+                    "/org/freedesktop/DBus", null, Gio.DBusSignalFlags.NO_MATCH_RULE, Lang.bind(this, this._onConnChange));
+            }));
+    },
 
-	_hdlListNames: function(conn, query){
-		let resp = conn.call_finish(query).get_child_value(0);
+    _hdlListNames: function(conn, query){
+        let resp = conn.call_finish(query).get_child_value(0);
 
-		for(let i = 0; i < resp.n_children(); i++){
-			let path = resp.get_child_value(i).get_string()[0];
-			if(path.search('^org.mpris.MediaPlayer2') == 0)
-				this._addMPRISStream(path, null);
-		}
+        for(let i = 0; i < resp.n_children(); i++){
+            let path = resp.get_child_value(i).get_string()[0];
+            if(path.search('^org.mpris.MediaPlayer2') == 0)
+                this._addMPRISStream(path, null);
+        }
 
-		this._parent._addExistingStreams();
-	},
+        this._parent._addExistingStreams();
+    },
 
-	_addMPRISStream: function(path, uname){
-		this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "GetConnectionUnixProcessID",
-			GLib.Variant.new('(s)', [path]), GLib.VariantType.new("(u)"), Gio.DBusCallFlags.NONE, -1, null,
-			Lang.bind(this, function(conn, query){
-				let pid = conn.call_finish(query).get_child_value(0).get_uint32();
-				if(!(pid in this._mprisStreams)){
-					this._mprisStreams[pid] = '';
+    _addMPRISStream: function(path, uname){
+        this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "GetConnectionUnixProcessID",
+            GLib.Variant.new('(s)', [path]), GLib.VariantType.new("(u)"), Gio.DBusCallFlags.NONE, -1, null,
+            Lang.bind(this, function(conn, query){
+                let pid = conn.call_finish(query).get_child_value(0).get_uint32();
+                if(!(pid in this._mprisStreams)){
+                    this._mprisStreams[pid] = '';
 
-					let add = Lang.bind(this, function(uname){
-						let nStr = new MPRISStream(this._parent, uname, pid, this._dbus, this._paDBus);
-						this._mprisStreams[pid] = nStr;
-						this.actor.add(nStr.actor);
-					});
+                    let add = Lang.bind(this, function(uname){
+                        let nStr = new MPRISStream(this._parent, uname, pid, this._dbus, this._paDBus);
+                        this._mprisStreams[pid] = nStr;
+                        this.actor.add(nStr.actor);
+                    });
 
-					if(uname == null){
-						this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "GetNameOwner",
-							GLib.Variant.new('(s)', [path]), GLib.VariantType.new('(s)'), Gio.DBusCallFlags.NONE, -1, null,
-							Lang.bind(this, function(conn, query){
-								let resp = conn.call_finish(query);
-								resp = resp.get_child_value(0).unpack();
-								if(resp != null)
-									add(resp);
-							})
-						);
-					}
+                    if(uname == null){
+                        this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "GetNameOwner",
+                            GLib.Variant.new('(s)', [path]), GLib.VariantType.new('(s)'), Gio.DBusCallFlags.NONE, -1, null,
+                            Lang.bind(this, function(conn, query){
+                                let resp = conn.call_finish(query);
+                                resp = resp.get_child_value(0).unpack();
+                                if(resp != null)
+                                    add(resp);
+                            })
+                        );
+                    }
 
-					if(uname != null){
-						add(uname);
-					}
-				}
-			})
-		);
-	},
+                    if(uname != null){
+                        add(uname);
+                    }
+                }
+            })
+        );
+    },
 
-	removePAStream:function(path){
-		for(let pid in this._mprisStreams){
-			if(this._mprisStreams[pid]._paPath == path){
-				this._mprisStreams[pid].unsetPAStream();
-				break;
-			}
-		}
-	},
+    removePAStream:function(path){
+        for(let pid in this._mprisStreams){
+            if(this._mprisStreams[pid]._paPath == path){
+                this._mprisStreams[pid].unsetPAStream();
+                break;
+            }
+        }
+    },
 
-	isMPRISStream: function(pid, path){
-		if(pid in this._mprisStreams){
-			let obj = this._mprisStreams[pid];
-			if(obj == '')
-				//The pid has been registered however the object hasn't been created yet, so a timeout of 2 seconds lapses before
-				//trying to reregister the pa stream.
-				Loop.timeout_add_seconds(2, Lang.bind(this, function(){
-					try{
-						this._mprisStreams[pid].setPAStream(path);
-					} catch(e){
-						log("Laine Exception: "+e);
-					}
-				}));
-			else
-				obj.setPAStream(path);
-			return true;
-		}
-		return false;
-	},
+    isMPRISStream: function(pid, path){
+        if(pid in this._mprisStreams){
+            let obj = this._mprisStreams[pid];
+            if(obj == '')
+                //The pid has been registered however the object hasn't been created yet, so a timeout of 2 seconds lapses before
+                //trying to reregister the pa stream.
+                Loop.timeout_add_seconds(2, Lang.bind(this, function(){
+                    try{
+                        this._mprisStreams[pid].setPAStream(path);
+                    } catch(e){
+                        log("Laine Exception: "+e);
+                    }
+                }));
+            else
+                obj.setPAStream(path);
+            return true;
+        }
+        return false;
+    },
 
-	_onConnChange: function(conn, sender, object, iface, signal, param, user_data){
-		let path = param.get_child_value(0).get_string()[0];
-		let add = (param.get_child_value(1).get_string()[0] == '');
+    _onConnChange: function(conn, sender, object, iface, signal, param, user_data){
+        let path = param.get_child_value(0).get_string()[0];
+        let add = (param.get_child_value(1).get_string()[0] == '');
 
-		if(path.search('^org.mpris.MediaPlayer2') != 0)
-			return;
+        if(path.search('^org.mpris.MediaPlayer2') != 0)
+            return;
 
-		if(add){
-			let uName = param.get_child_value(2).get_string()[0];
-			this._addMPRISStream(path, uName);
-		}
-		else {
-			for(let k in this._mprisStreams){
-				let uName = param.get_child_value(1).get_string()[0];
-				if(this._mprisStreams[k]._path == uName){
-					this._mprisStreams[k].destroy();
-					delete this._mprisStreams[k];
-					this.actor.queue_relayout();
-					break;
-				}
-			}
-		}
-	},
+        if(add){
+            let uName = param.get_child_value(2).get_string()[0];
+            this._addMPRISStream(path, uName);
+        }
+        else {
+            for(let k in this._mprisStreams){
+                let uName = param.get_child_value(1).get_string()[0];
+                if(this._mprisStreams[k]._path == uName){
+                    this._mprisStreams[k].destroy();
+                    delete this._mprisStreams[k];
+                    this.actor.queue_relayout();
+                    break;
+                }
+            }
+        }
+    },
 
-	_onDestroy: function(){
-		this._dbus.signal_unsubscribe(this._sigNOC);
-		this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "RemoveMatch",
-			GLib.Variant.new('(s)', [WATCH_RULE]), null, Gio.DBusCallFlags.NONE, -1, null, null);
-	}
+    _onDestroy: function(){
+        this._dbus.signal_unsubscribe(this._sigNOC);
+        this._dbus.call('org.freedesktop.DBus', '/', "org.freedesktop.DBus", "RemoveMatch",
+            GLib.Variant.new('(s)', [WATCH_RULE]), null, Gio.DBusCallFlags.NONE, -1, null, null);
+    }
 
 });
 
 const MPRISStream = new Lang.Class({
-	Name: 'MPRISStream',
-	Extends: StreamBase,
-
-	_init: function(parent, dbusPath, pid, dbus, paconn){
-		this.parent(parent, paconn);
-		this._path = dbusPath;
-		this._procID = pid;
-		this._dbus = dbus;
-		this._mediaLength = 0;
-		this._sigFVol = this._sigFMute = -1;
-		this.actor.add_style_class_name("mpris-stream");
-		this._label.add_style_pseudo_class('clickable');
-
-		this.unsetPAStream();
-
-		this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-			GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2', 'DesktopEntry']), GLib.VariantType.new("(v)"),
-			Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, this._hdlDesktopEntry));
-
-		this._songLbl = new St.Label({style_class:'mpris-meta-title'});
-		this._artistLbl = new St.Label({style_class:'mpris-meta-info'});
-		this._albumLbl = new St.Label({style_class:'mpris-meta-info'});
-		this._albumArt = new St.Icon({style_class:'mpris-album-art'});
-
-		this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-			GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Metadata']), GLib.VariantType.new("(v)"),
-			Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				let response = conn.call_finish(query).get_child_value(0).unpack();
-				this._updateMetadata(response);
-			})
-		);
-
-		this._playBtn = new St.Button({child: new St.Icon({icon_name: 'media-playback-start-symbolic'}), style_class:'mpris-play-button', reactive:true, can_focus:true});
-		this._prevBtn = new St.Button({child: new St.Icon({icon_name: 'media-skip-backward-symbolic'}), style_class:'mpris-previous-button', reactive:true, can_focus:true});
-		this._nextBtn = new St.Button({child: new St.Icon({icon_name: 'media-skip-forward-symbolic'}), style_class:'mpris-next-button', reactive:true, can_focus:true});
-
-		this._posSlider = new Slider.Slider(0);
-		this._timeLapLbl = new St.Label({style_class:'mpris-time-label'});
-		this._timeRemLbl = new St.Label({style_class:'mpris-time-label'});
-
-		this._artistBox = new St.BoxLayout();
-		this._artistBox.add(new St.Label({text:_("by"), style_class:'mpris-label-subtext'}));
-		this._artistBox.add(this._artistLbl);
-		this._albumBox = new St.BoxLayout();
-		this._albumBox.add(new St.Label({text:_("from"), style_class:'mpris-label-subtext'}));
-		this._albumBox.add(this._albumLbl);
-		this._detailBox = new St.BoxLayout({vertical:true});
-		this._detailBox.add(this._songLbl);
-		this._detailBox.add(this._artistBox);
-		this._detailBox.add(this._albumBox);
-		this._sigUpdPos = 0;
-
-		let mediaControls = new St.BoxLayout({style_class: 'mpris-player-controls'});
-		mediaControls.add(this._prevBtn);
-		mediaControls.add(this._playBtn);
-		mediaControls.add(this._nextBtn);
-
-		let innerBox = new St.BoxLayout({vertical:true, style_class:'mpris-info-and-controls'});
-		innerBox.add(this._detailBox);
-		innerBox.add(mediaControls);
-
-		this._metaDisplay = new St.BoxLayout({style_class:'mpris-metadata-display'});
-		this._metaDisplay.add(this._albumArt);
-		this._metaDisplay.add(innerBox);
-
-		this._timeBox = new St.BoxLayout({style_class:'mpris-time-display'});
-		this._timeBox.add(this._timeLapLbl);
-		this._timeBox.add(this._posSlider.actor, {expand:true});
-		this._timeBox.add(this._timeRemLbl);
-
-		this.actor.add(this._metaDisplay);
-		this.actor.add(this._timeBox, {expand:true});
-
-		this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-			GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'PlaybackStatus']), GLib.VariantType.new("(v)"),
-			Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				let response = conn.call_finish(query).get_child_value(0).unpack().get_string()[0];
-				if(response == 'Playing')
-					this._setStatePlaying();
-				else if(response == 'Paused'){
-					this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-						GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Position']), GLib.VariantType.new("(v)"),
-						Gio.DBusCallFlags.NONE, -1, null,
-						Lang.bind(this, function(conn, query){
-							let response = conn.call_finish(query).get_child_value(0).unpack();
-							this._mediaPosition = response.get_int64();
-
-							this._timeLapLbl.text = this._formatSeconds(Math.floor(this._mediaPosition/1000000));
-							this._timeRemLbl.text = '-'+this._formatSeconds(Math.floor((this._mediaLength - this._mediaPosition)/1000000));
-							this._posSlider.setValue(this._mediaPosition/this._mediaLength);
-						})
-					);
-				}
-				else if(response == 'Stopped'){
-					this._prevBtn.hide();
-					this._nextBtn.hide();
-					this._timeBox.hide();
-					this._detailBox.hide();
-					this._albumArt.hide();
-
-					this.actor.set_vertical(false);
-					this.actor.add_style_pseudo_class('alone');
-					this._metaDisplay.add_style_pseudo_class('alone');
-					this._playBtn.add_style_pseudo_class('alone');
-					this._volCtrl.add_style_pseudo_class('alone');
-				}
-			})
-		);
-
-		//Signal handlers
-		this._sigPropChange = this._dbus.signal_subscribe(this._path, 'org.freedesktop.DBus.Properties',
-			'PropertiesChanged', '/org/mpris/MediaPlayer2', null, Gio.DBusSignalFlags.NONE,
-			Lang.bind(this, this._onPropChange), null);
-		this._sigSeeked = this._dbus.signal_subscribe(this._path, 'org.mpris.MediaPlayer2.Player',
-			'Seeked', '/org/mpris/MediaPlayer2', null, Gio.DBusSignalFlags.NONE,
-			Lang.bind(this, this._onPropChange), null);
-
-		this._posSlider.connect('value-changed', Lang.bind(this, this._onPosSliderChange));
-
-		this._playBtn.connect('clicked', Lang.bind(this, this._onControlBtnClick));
-		this._nextBtn.connect('clicked', Lang.bind(this, this._onControlBtnClick));
-		this._prevBtn.connect('clicked', Lang.bind(this, this._onControlBtnClick));
-
-		this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
-
-		this._label.connect('button-press-event', Lang.bind(this, this._raise));
-
-
-		this._volSlider.actor.set_track_hover(true);
-		this._volSlider.actor.connect('key-press-event', Lang.bind(this, this._onVolSliderKeyPress));
-
-		this._volSlider.actor.connect('notify::hover', Lang.bind(this, function(){
-			this._setFocused(this._volSlider.actor.hover, 'active-top');
-		}));
-		this._posSlider.actor.set_track_hover(true);
-		this._posSlider.actor.connect('notify::hover', Lang.bind(this, function(){
-			this._setFocused(this._posSlider.actor.hover, 'active-bottom');
-		}));
-		this._label.connect('notify::hover', Lang.bind(this, function(){
-			this._setFocused(this._label.hover, 'active-top');
-		}));
-
-		this._muteBtn.set_track_hover(true);
-		this._muteBtn.connect('notify::hover', Lang.bind(this, function(){
-			this._setFocused(this._muteBtn.hover, 'active-top');
-		}));
-
-		this._volSlider.actor.connect('key-focus-in', Lang.bind(this, function(){ this._setFocused(true, 'active-top'); }));
-		this._volSlider.actor.connect('key-focus-out', Lang.bind(this, function(){ this._setFocused(false, 'active-top'); }));
-		this._posSlider.actor.connect('key-focus-in', Lang.bind(this, function(){ this._setFocused(true, 'active-bottom'); }));
-		this._posSlider.actor.connect('key-focus-out', Lang.bind(this, function(){ this._setFocused(false, 'active-bottom'); }));
-
-	},
-
-	_setFocused: function(activate, type){
-		if(activate)
-			this.actor.add_style_pseudo_class(type);
-		else
-			this.actor.remove_style_pseudo_class(type);
-	},
-
-		//Async functions
-	_hdlDesktopEntry: function(conn, result){
-		let res = conn.call_finish(result);
-		res = res.get_child_value(0).unpack();
-
-		let dName = res.get_string()[0];
-		let icon;
-		let app = Shell.AppSystem.get_default().lookup_app(dName+".desktop");
-		if(app != null){
-			let info = app.get_app_info();
-			this._label.text = info.get_name();
-			icon = new St.Icon({style_class: 'icon'});
-			icon.set_gicon(info.get_icon());
-		} else {
-			icon = new St.Icon({icon_name: 'package_multimedia', style_class: 'simple-stream-icon'});
-			this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-				GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2', 'Identity']), GLib.VariantType.new("(v)"),
-				Gio.DBusCallFlags.NONE, -1, null,
-				Lang.bind(this, function(conn, query){
-					let res = conn.call_finish(query).get_child_value(0).get_string()[0];
-					this.label.text = res;
-				})
-			);
-		}
-
-		this._muteBtn.child = icon;
-	},
-
-	setPAStream: function(path){
-		if(this._sigFVol != -1){
-			this._volSlider.disconnect(this._sigFVol);
-			this._muteBtn.disconnect(this._sigFMute);
-
-			this._sigFMute = this._sigFVol = -1;
-		}
-
-		this.setPAPath(path);
-	},
-
-	unsetPAStream: function(){
-		if(this._paPath){
-			this._paDBus.signal_unsubscribe(this._sigVol);
-			this._paDBus.signal_unsubscribe(this._sigMute);
-		}
-
-		this._paPath = null;
-
-		this._sigFVol = this._volSlider.connect('value-changed',
-			Lang.bind(this, function(slider, value, property){
-				this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Set",
-					GLib.Variant.new('(ssv)', ['org.mpris.MediaPlayer2.Player', 'Volume', GLib.Variant.new_double(value)]),
-					null, Gio.DBusCallFlags.NONE, -1, null, null);
-			})
-		);
-		this._sigFMute = this._muteBtn.connect('clicked', Lang.bind(this, function(){
-				this._muteVal = !this._muteVal;
-				this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Set",
-					GLib.Variant.new('(ssv)', ['org.mpris.MediaPlayer2.Player', 'Volume', GLib.Variant.new_double(this._muteVal?0:this._appVol)]),
-					null, Gio.DBusCallFlags.NONE, -1, null, null);
-			})
-		);
-	},
-
-
-	_updateMetadata: function(meta){
-		if(meta == null || meta.n_children() == 0){
-			this._prevBtn.hide();
-			this._nextBtn.hide();
-			this._timeBox.hide();
-			this._detailBox.hide();
-			this._albumArt.hide();
-
-			this.actor.set_vertical(false);
-			this.actor.add_style_pseudo_class('alone');
-			this._metaDisplay.add_style_pseudo_class('alone');
-			this._playBtn.add_style_pseudo_class('alone');
-			this._volCtrl.add_style_pseudo_class('alone');
-		}
-		else {
-
-			this.actor.set_vertical(true);
-			this.actor.remove_style_pseudo_class('alone');
-			this._metaDisplay.remove_style_pseudo_class('alone');
-			this._playBtn.remove_style_pseudo_class('alone');
-			this._volCtrl.remove_style_pseudo_class('alone');
-
-			this._prevBtn.show();
-			this._nextBtn.show();
-
-			let metaD = {};
-			for(let i = 0; i < meta.n_children(); i++){
-				let [key, val] = meta.get_child_value(i).unpack();
-
-				key = key.get_string()[0];
-				val = val.unpack();
-				metaD[key] = val;
-			}
-
-			if('xesam:title' in metaD){
-				this._songLbl.text = metaD['xesam:title'].get_string()[0];
-				this._songLbl.show();
-				this._detailBox.show();
-			} else {
-				this._songLbl.hide();
-			}
-
-			if('xesam:artist' in metaD){
-				let artists = metaD['xesam:artist'];
-				let str = artists.get_child_value(0).get_string()[0];
-
-				for(let i = 1; i < artists.n_children(); i++)
-					str += ', '+artists.get_child_value(i).get_string()[0];
-
-				this._artistLbl.text = str;
-				this._artistBox.show();
-			} else {
-				this._artistBox.hide();
-			}
-
-			if('xesam:album' in metaD){
-				this._albumLbl.text = metaD['xesam:album'].get_string()[0];
-				this._albumBox.show();
-			} else {
-				this._albumBox.hide();
-			}
-			try{
-				if('mpris:artUrl' in metaD){
-					let filePath = metaD['mpris:artUrl'].get_string()[0];
-					filePath = decodeURI(filePath);
-
-					if(filePath.match(/http/)){
-						let file = Gio.file_new_for_uri(filePath);
-						file.read_async(null, null, Lang.bind(this, this._setIcon));
-					}
-					else if(filePath.match(/file/)) {
-						let iconPath = filePath.substring(7, filePath.length);
-						if(GLib.file_test(iconPath, GLib.FileTest.EXISTS)){
-							let file = Gio.File.new_for_path(iconPath);
-							this._setIcon(file, null);
-						}
-					}
-					else throw "album art url misformed";
-				}
-				else throw "no album art";
-
-				this._albumArt.remove_style_pseudo_class('generic');
-			}
-			catch(err){
-				this._albumArt.icon_name = 'folder-music-symbolic';
-				this._albumArt.add_style_pseudo_class('generic');
-			}
-			finally{
-				this._albumArt.show();
-			}
-
-			if('mpris:trackid' in metaD || 'xesam:url' in metaD) {
-				if('mpris:trackid' in metaD)
-					this._mediaID = metaD['mpris:trackid'].get_string()[0];
-
-				this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-					GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Position']), GLib.VariantType.new("(v)"),
-					Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-						try{
-							let response = conn.call_finish(query).get_child_value(0).unpack();
-							this._mediaPosition = response.get_int64();
-						}
-						catch(err){
-							if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: No such property"))
-								throw err;
-						}
-					})
-				);
-			}
-
-			this._mediaLength = 0;
-			if('mpris:length' in metaD){
-				this._mediaLength = metaD['mpris:length'].get_int64();
-
-				if(this._mediaLength == -1 && this._label.text == 'VLC media player') {
-					//VLC sends this field as a negative number when you are listening for the value, but sends the correct reply if you ask
-					//for metadata explicatly.  So lets try once asking directly for metadata.
-					this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-						GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Metadata']), GLib.VariantType.new("(v)"),
-						Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-							let meta = conn.call_finish(query).get_child_value(0).unpack();
-							for(let i = 0; i < meta.n_children(); i++){
-								let [key, val] = meta.get_child_value(i).unpack();
-								key = key.get_string()[0];
-								if(key == 'mpris:length'){
-									this._mediaLength = val.unpack().get_int64();
-									break;
-								}
-							}
-						})
-					);
-				}
-			}
-
-			if(this._mediaLength <= 0)
-				this._timeBox.hide();
-			else
-				this._timeBox.show();
-		}
-	},
-
-	_setStatePlaying: function(){
-		this._playBtn.child.icon_name = 'media-playback-pause-symbolic';
-
-		this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-			GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Position']), GLib.VariantType.new("(v)"),
-			Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				try{
-					let response = conn.call_finish(query).get_child_value(0).unpack();
-					this._mediaPosition = response.get_int64();
-
-					if(this._sigUpdPos == 0)
-						this._sigUpdPos = Loop.timeout_add_seconds(1, Lang.bind(this, this._updatePosition));
-				} catch(err){
-					//not all players support position (e.g. Nuvola) so if this exception is thrown, do nothing.
-					if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: No such property"))
-						throw err;
-				}
-			})
-		);
-		this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-			GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Rate']), GLib.VariantType.new("(v)"),
-			Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-				try{
-					let response = conn.call_finish(query).get_child_value(0).unpack();
-					this._mediaRate = response.get_double();
-				} catch(err){
-					//not all players support rate (e.g. Nuvola) so if this exception is thrown, do nothing.
-					if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: No such property"))
-						throw err;
-				}
-			})
-		);
-	},
-
-	_onPropChange: function(conn, sender, object, iface, signal, param, user_data){
-		if(signal == 'PropertiesChanged'){
-			let sIface = param.get_child_value(0).get_string()[0];
-
-			if(sIface == 'org.mpris.MediaPlayer2.Player'){
-				let sigs = param.get_child_value(1);
-				for(let i = 0; i < sigs.n_children(); i++){
-					let [key, val] = sigs.get_child_value(i).unpack();
-					key = key.get_string()[0];
-					val = val.unpack();
-
-					if(key == 'Metadata')
-						this._updateMetadata(val);
-					else if(key == 'PlaybackStatus'){
-						let state = val.get_string()[0];
-						if(state == 'Playing'){
-							this._setStatePlaying();
-						}
-						else {
-							if (this._sigUpdPos != 0) {
-								Loop.source_remove(this._sigUpdPos);
-								this._sigUpdPos = 0;
-							}
-							this._playBtn.child.icon_name = 'media-playback-start-symbolic';
-						}
-					}
-					else if(key == 'Volume' && this._paPath != null){
-						let vol = val.get_double();
-						if(!this._muteVal) this._appVol = vol;
-						if(this._paPath == null)
-							this._volSlider.setValue(vol);
-					}
-				}
-
-
-			}
-		} else if(signal == 'Seeked'){
-			//Have to manually get the time as banshee doesn't send it.
-			this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-				GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Position']), GLib.VariantType.new("(v)"),
-				Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
-					let response = conn.call_finish(query).get_child_value(0).unpack();
-					this._mediaPosition = response.get_int64();
-				})
-			);
-		}
-	},
-
-	_onControlBtnClick: function(button){
-		if(button == this._playBtn){
-			this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2.Player", "PlayPause",
-				null, null, Gio.DBusCallFlags.NONE, -1, null, null);
-		}
-		else if(button == this._prevBtn){
-			this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2.Player", "Previous",
-				null, null, Gio.DBusCallFlags.NONE, -1, null, null);
-		}
-		else if(button == this._nextBtn){
-			this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2.Player", "Next",
-				null, null, Gio.DBusCallFlags.NONE, -1, null, null);
-		}
-	},
-
-	_onVolSliderKeyPress: function(actor, event) {
-		let key = event.get_key_symbol();
-
-		if(key == Clutter.KEY_space || key == Clutter.KEY_Return) {
-			this.setVolume(!this._muteVal);
-			return Clutter.EVENT_STOP;
-		}
-		return Clutter.EVENT_PROPAGATE;
-	},
-
-	_onPosSliderChange: function(slider, value, property){
-		if(this._mediaLength != 0){
-			let position = Math.floor(value * this._mediaLength);
-			this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2.Player", "SetPosition",
-					GLib.Variant.new('(ox)', [this._mediaID, position]), null,
-					Gio.DBusCallFlags.NONE, -1, null, null );
-		}
-	},
-
-	_updatePosition: function(){
-		if(this._mediaLength > 0 && this._mediaLength >= this._mediaPosition){
-			this._sigUpdPos = Loop.timeout_add_seconds(1, Lang.bind(this, this._updatePosition));
-
-			this._mediaPosition += 1000000*this._mediaRate;
-			this._timeLapLbl.text = this._formatSeconds(Math.floor(this._mediaPosition/1000000));
-			this._timeRemLbl.text = '-'+this._formatSeconds(Math.floor((this._mediaLength - this._mediaPosition)/1000000));
-			this._posSlider.setValue(this._mediaPosition/this._mediaLength);
-		}
-	},
-
-	_formatSeconds: function(seconds){
-		let mod = seconds % 60
-		let ans = mod.toString();
-		if(mod < 10) ans = '0'+ans;
-		seconds = Math.floor(seconds/60);
-		if(seconds > 0){
-			ans = (seconds % 60) + ':' + ans;
-			seconds = Math.floor(seconds/60);
-		}
-		else
-			ans = '0:'+ans;
-		if(seconds > 0)
-			ans = seconds +':'+ans;
-		return ans;
-	},
-
-	_raise: function(){
-		if(this._app == null){
-			this._app = WindowTracker.get_app_from_pid(this._procID);
-
-			if(this._app == null){//Check the tray
-				let trayNotifications = Main.messageTray.getSources();
-				for(let i = 0; i < trayNotifications.length; i++)
-					if(trayNotifications[i].pid == this._procID)
-						this._app = trayNotifications[i].app;
-			}
-
-			if(this._app == null){//try raising a window via dbus
-				this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
-					GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2', 'CanRaise']), GLib.VariantType.new("(v)"),
-					Gio.DBusCallFlags.NONE, -1, null,
-					Lang.bind(this, function(conn, query){
-						let response = conn.call_finish(query).get_child_value(0).unpack();
-						if(response.get_boolean()){
-							this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2", "Raise",
-								null, null, Gio.DBusCallFlags.NONE, -1, null, null);
-							this._app = WindowTracker.get_app_from_pid(this._procID);
-						}
-					})
-				);
-			}
-
-		}
-		if(this._app != null){
-			this._app.activate();
-			this._parent._getTopMenu().close(BoxPointer.PopupAnimation.FULL);
-		}
-	},
-
-	_setIcon: function(file, result){
-		if(result != null){
-			if(this._tmpIcon) this._tmpIcon.delete(null);
-			this._tmpIcon = Gio.file_new_tmp("laine.XXXXXX")[0];
-
-			let inStr = file.read_finish(result);
-			let outStr = this._tmpIcon.replace(null, false,
-				Gio.FileCreateFlags.REPLACE_DESTINATION, null, null);
-			outStr.splice(inStr,
-				Gio.OutputStreamSpliceFlags.CLOSE_SOURCE |
-				Gio.OutputStreamSpliceFlags.CLOSE_TARGET, null);
-			file = this._tmpIcon;
-		}
-
-		let icon = new Gio.FileIcon({file:file});
-		this._albumArt.set_gicon(icon);
-
-		this._albumArt.show();
-	},
-
-	_onDestroy: function(){
-		this._dbus.signal_unsubscribe(this._sigPropChange);
-		this._dbus.signal_unsubscribe(this._sigSeeked);
-		if(this._paPath){
-			this._paDBus.signal_unsubscribe(this._sigVol);
-			this._paDBus.signal_unsubscribe(this._sigMute);
-		}
-		if(this._sigUpdPos != 0) {
-			Loop.source_remove(this._sigUpdPos);
-			this._sigUpdPos = 0;
-		}
-
-		if(this._tmpIcon)
-			this._tmpIcon.delete(null);
-	}
+    Name: 'MPRISStream',
+    Extends: StreamBase,
+
+    _init: function(parent, dbusPath, pid, dbus, paconn){
+        this.parent(parent, paconn);
+        this._path = dbusPath;
+        this._procID = pid;
+        this._dbus = dbus;
+        this._mediaLength = 0;
+        this._sigFVol = this._sigFMute = -1;
+        this.actor.add_style_class_name("mpris-stream");
+        this._label.add_style_pseudo_class('clickable');
+
+        this.unsetPAStream();
+
+        this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+            GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2', 'DesktopEntry']), GLib.VariantType.new("(v)"),
+            Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, this._hdlDesktopEntry));
+
+        this._songLbl = new St.Label({style_class:'mpris-meta-title'});
+        this._artistLbl = new St.Label({style_class:'mpris-meta-info'});
+        this._albumLbl = new St.Label({style_class:'mpris-meta-info'});
+        this._albumArt = new St.Icon({style_class:'mpris-album-art'});
+
+        this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+            GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Metadata']), GLib.VariantType.new("(v)"),
+            Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                let response = conn.call_finish(query).get_child_value(0).unpack();
+                this._updateMetadata(response);
+            })
+        );
+
+        this._playBtn = new St.Button({child: new St.Icon({icon_name: 'media-playback-start-symbolic'}), style_class:'mpris-play-button', reactive:true, can_focus:true});
+        this._prevBtn = new St.Button({child: new St.Icon({icon_name: 'media-skip-backward-symbolic'}), style_class:'mpris-previous-button', reactive:true, can_focus:true});
+        this._nextBtn = new St.Button({child: new St.Icon({icon_name: 'media-skip-forward-symbolic'}), style_class:'mpris-next-button', reactive:true, can_focus:true});
+
+        this._posSlider = new Slider.Slider(0);
+        this._timeLapLbl = new St.Label({style_class:'mpris-time-label'});
+        this._timeRemLbl = new St.Label({style_class:'mpris-time-label'});
+
+        this._artistBox = new St.BoxLayout();
+        this._artistBox.add(new St.Label({text:_("by"), style_class:'mpris-label-subtext'}));
+        this._artistBox.add(this._artistLbl);
+        this._albumBox = new St.BoxLayout();
+        this._albumBox.add(new St.Label({text:_("from"), style_class:'mpris-label-subtext'}));
+        this._albumBox.add(this._albumLbl);
+        this._detailBox = new St.BoxLayout({vertical:true});
+        this._detailBox.add(this._songLbl);
+        this._detailBox.add(this._artistBox);
+        this._detailBox.add(this._albumBox);
+        this._sigUpdPos = 0;
+
+        let mediaControls = new St.BoxLayout({style_class: 'mpris-player-controls'});
+        mediaControls.add(this._prevBtn);
+        mediaControls.add(this._playBtn);
+        mediaControls.add(this._nextBtn);
+
+        let innerBox = new St.BoxLayout({vertical:true, style_class:'mpris-info-and-controls'});
+        innerBox.add(this._detailBox);
+        innerBox.add(mediaControls);
+
+        this._metaDisplay = new St.BoxLayout({style_class:'mpris-metadata-display'});
+        this._metaDisplay.add(this._albumArt);
+        this._metaDisplay.add(innerBox);
+
+        this._timeBox = new St.BoxLayout({style_class:'mpris-time-display'});
+        this._timeBox.add(this._timeLapLbl);
+        this._timeBox.add(this._posSlider.actor, {expand:true});
+        this._timeBox.add(this._timeRemLbl);
+
+        this.actor.add(this._metaDisplay);
+        this.actor.add(this._timeBox, {expand:true});
+
+        this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+            GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'PlaybackStatus']), GLib.VariantType.new("(v)"),
+            Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                let response = conn.call_finish(query).get_child_value(0).unpack().get_string()[0];
+                if(response == 'Playing')
+                    this._setStatePlaying();
+                else if(response == 'Paused'){
+                    this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+                        GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Position']), GLib.VariantType.new("(v)"),
+                        Gio.DBusCallFlags.NONE, -1, null,
+                        Lang.bind(this, function(conn, query){
+                            let response = conn.call_finish(query).get_child_value(0).unpack();
+                            this._mediaPosition = response.get_int64();
+
+                            this._timeLapLbl.text = this._formatSeconds(Math.floor(this._mediaPosition/1000000));
+                            this._timeRemLbl.text = '-'+this._formatSeconds(Math.floor((this._mediaLength - this._mediaPosition)/1000000));
+                            this._posSlider.setValue(this._mediaPosition/this._mediaLength);
+                        })
+                    );
+                }
+                else if(response == 'Stopped'){
+                    this._prevBtn.hide();
+                    this._nextBtn.hide();
+                    this._timeBox.hide();
+                    this._detailBox.hide();
+                    this._albumArt.hide();
+
+                    this.actor.set_vertical(false);
+                    this.actor.add_style_pseudo_class('alone');
+                    this._metaDisplay.add_style_pseudo_class('alone');
+                    this._playBtn.add_style_pseudo_class('alone');
+                    this._volCtrl.add_style_pseudo_class('alone');
+                }
+            })
+        );
+
+        //Signal handlers
+        this._sigPropChange = this._dbus.signal_subscribe(this._path, 'org.freedesktop.DBus.Properties',
+            'PropertiesChanged', '/org/mpris/MediaPlayer2', null, Gio.DBusSignalFlags.NONE,
+            Lang.bind(this, this._onPropChange), null);
+        this._sigSeeked = this._dbus.signal_subscribe(this._path, 'org.mpris.MediaPlayer2.Player',
+            'Seeked', '/org/mpris/MediaPlayer2', null, Gio.DBusSignalFlags.NONE,
+            Lang.bind(this, this._onPropChange), null);
+
+        this._posSlider.connect('value-changed', Lang.bind(this, this._onPosSliderChange));
+
+        this._playBtn.connect('clicked', Lang.bind(this, this._onControlBtnClick));
+        this._nextBtn.connect('clicked', Lang.bind(this, this._onControlBtnClick));
+        this._prevBtn.connect('clicked', Lang.bind(this, this._onControlBtnClick));
+
+        this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
+
+        this._label.connect('button-press-event', Lang.bind(this, this._raise));
+
+
+        this._volSlider.actor.set_track_hover(true);
+        this._volSlider.actor.connect('key-press-event', Lang.bind(this, this._onVolSliderKeyPress));
+
+        this._volSlider.actor.connect('notify::hover', Lang.bind(this, function(){
+            this._setFocused(this._volSlider.actor.hover, 'active-top');
+        }));
+        this._posSlider.actor.set_track_hover(true);
+        this._posSlider.actor.connect('notify::hover', Lang.bind(this, function(){
+            this._setFocused(this._posSlider.actor.hover, 'active-bottom');
+        }));
+        this._label.connect('notify::hover', Lang.bind(this, function(){
+            this._setFocused(this._label.hover, 'active-top');
+        }));
+
+        this._muteBtn.set_track_hover(true);
+        this._muteBtn.connect('notify::hover', Lang.bind(this, function(){
+            this._setFocused(this._muteBtn.hover, 'active-top');
+        }));
+
+        this._volSlider.actor.connect('key-focus-in', Lang.bind(this, function(){ this._setFocused(true, 'active-top'); }));
+        this._volSlider.actor.connect('key-focus-out', Lang.bind(this, function(){ this._setFocused(false, 'active-top'); }));
+        this._posSlider.actor.connect('key-focus-in', Lang.bind(this, function(){ this._setFocused(true, 'active-bottom'); }));
+        this._posSlider.actor.connect('key-focus-out', Lang.bind(this, function(){ this._setFocused(false, 'active-bottom'); }));
+
+    },
+
+    _setFocused: function(activate, type){
+        if(activate)
+            this.actor.add_style_pseudo_class(type);
+        else
+            this.actor.remove_style_pseudo_class(type);
+    },
+
+        //Async functions
+    _hdlDesktopEntry: function(conn, result){
+        let res = conn.call_finish(result);
+        res = res.get_child_value(0).unpack();
+
+        let dName = res.get_string()[0];
+        let icon;
+        let app = Shell.AppSystem.get_default().lookup_app(dName+".desktop");
+        if(app != null){
+            let info = app.get_app_info();
+            this._label.text = info.get_name();
+            icon = new St.Icon({style_class: 'icon'});
+            icon.set_gicon(info.get_icon());
+        } else {
+            icon = new St.Icon({icon_name: 'package_multimedia', style_class: 'simple-stream-icon'});
+            this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+                GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2', 'Identity']), GLib.VariantType.new("(v)"),
+                Gio.DBusCallFlags.NONE, -1, null,
+                Lang.bind(this, function(conn, query){
+                    let res = conn.call_finish(query).get_child_value(0).get_string()[0];
+                    this.label.text = res;
+                })
+            );
+        }
+
+        this._muteBtn.child = icon;
+    },
+
+    setPAStream: function(path){
+        if(this._sigFVol != -1){
+            this._volSlider.disconnect(this._sigFVol);
+            this._muteBtn.disconnect(this._sigFMute);
+
+            this._sigFMute = this._sigFVol = -1;
+        }
+
+        this.setPAPath(path);
+    },
+
+    unsetPAStream: function(){
+        if(this._paPath){
+            this._paDBus.signal_unsubscribe(this._sigVol);
+            this._paDBus.signal_unsubscribe(this._sigMute);
+        }
+
+        this._paPath = null;
+
+        this._sigFVol = this._volSlider.connect('value-changed',
+            Lang.bind(this, function(slider, value, property){
+                this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Set",
+                    GLib.Variant.new('(ssv)', ['org.mpris.MediaPlayer2.Player', 'Volume', GLib.Variant.new_double(value)]),
+                    null, Gio.DBusCallFlags.NONE, -1, null, null);
+            })
+        );
+        this._sigFMute = this._muteBtn.connect('clicked', Lang.bind(this, function(){
+                this._muteVal = !this._muteVal;
+                this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Set",
+                    GLib.Variant.new('(ssv)', ['org.mpris.MediaPlayer2.Player', 'Volume', GLib.Variant.new_double(this._muteVal?0:this._appVol)]),
+                    null, Gio.DBusCallFlags.NONE, -1, null, null);
+            })
+        );
+    },
+
+
+    _updateMetadata: function(meta){
+        if(meta == null || meta.n_children() == 0){
+            this._prevBtn.hide();
+            this._nextBtn.hide();
+            this._timeBox.hide();
+            this._detailBox.hide();
+            this._albumArt.hide();
+
+            this.actor.set_vertical(false);
+            this.actor.add_style_pseudo_class('alone');
+            this._metaDisplay.add_style_pseudo_class('alone');
+            this._playBtn.add_style_pseudo_class('alone');
+            this._volCtrl.add_style_pseudo_class('alone');
+        }
+        else {
+
+            this.actor.set_vertical(true);
+            this.actor.remove_style_pseudo_class('alone');
+            this._metaDisplay.remove_style_pseudo_class('alone');
+            this._playBtn.remove_style_pseudo_class('alone');
+            this._volCtrl.remove_style_pseudo_class('alone');
+
+            this._prevBtn.show();
+            this._nextBtn.show();
+
+            let metaD = {};
+            for(let i = 0; i < meta.n_children(); i++){
+                let [key, val] = meta.get_child_value(i).unpack();
+
+                key = key.get_string()[0];
+                val = val.unpack();
+                metaD[key] = val;
+            }
+
+            if('xesam:title' in metaD){
+                this._songLbl.text = metaD['xesam:title'].get_string()[0];
+                this._songLbl.show();
+                this._detailBox.show();
+            } else {
+                this._songLbl.hide();
+            }
+
+            if('xesam:artist' in metaD){
+                let artists = metaD['xesam:artist'];
+                let str = artists.get_child_value(0).get_string()[0];
+
+                for(let i = 1; i < artists.n_children(); i++)
+                    str += ', '+artists.get_child_value(i).get_string()[0];
+
+                this._artistLbl.text = str;
+                this._artistBox.show();
+            } else {
+                this._artistBox.hide();
+            }
+
+            if('xesam:album' in metaD){
+                this._albumLbl.text = metaD['xesam:album'].get_string()[0];
+                this._albumBox.show();
+            } else {
+                this._albumBox.hide();
+            }
+            try{
+                if('mpris:artUrl' in metaD){
+                    let filePath = metaD['mpris:artUrl'].get_string()[0];
+                    filePath = decodeURI(filePath);
+
+                    if(filePath.match(/http/)){
+                        let file = Gio.file_new_for_uri(filePath);
+                        file.read_async(null, null, Lang.bind(this, this._setIcon));
+                    }
+                    else if(filePath.match(/file/)) {
+                        let iconPath = filePath.substring(7, filePath.length);
+                        if(GLib.file_test(iconPath, GLib.FileTest.EXISTS)){
+                            let file = Gio.File.new_for_path(iconPath);
+                            this._setIcon(file, null);
+                        }
+                    }
+                    else throw "album art url misformed";
+                }
+                else throw "no album art";
+
+                this._albumArt.remove_style_pseudo_class('generic');
+            }
+            catch(err){
+                this._albumArt.icon_name = 'folder-music-symbolic';
+                this._albumArt.add_style_pseudo_class('generic');
+            }
+            finally{
+                this._albumArt.show();
+            }
+
+            if('mpris:trackid' in metaD || 'xesam:url' in metaD) {
+                if('mpris:trackid' in metaD)
+                    this._mediaID = metaD['mpris:trackid'].get_string()[0];
+
+                this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+                    GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Position']), GLib.VariantType.new("(v)"),
+                    Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                        try{
+                            let response = conn.call_finish(query).get_child_value(0).unpack();
+                            this._mediaPosition = response.get_int64();
+                        }
+                        catch(err){
+                            if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: No such property"))
+                                throw err;
+                        }
+                    })
+                );
+            }
+
+            this._mediaLength = 0;
+            if('mpris:length' in metaD){
+                this._mediaLength = metaD['mpris:length'].get_int64();
+
+                if(this._mediaLength == -1 && this._label.text == 'VLC media player') {
+                    //VLC sends this field as a negative number when you are listening for the value, but sends the correct reply if you ask
+                    //for metadata explicatly.  So lets try once asking directly for metadata.
+                    this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+                        GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Metadata']), GLib.VariantType.new("(v)"),
+                        Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                            let meta = conn.call_finish(query).get_child_value(0).unpack();
+                            for(let i = 0; i < meta.n_children(); i++){
+                                let [key, val] = meta.get_child_value(i).unpack();
+                                key = key.get_string()[0];
+                                if(key == 'mpris:length'){
+                                    this._mediaLength = val.unpack().get_int64();
+                                    break;
+                                }
+                            }
+                        })
+                    );
+                }
+            }
+
+            if(this._mediaLength <= 0)
+                this._timeBox.hide();
+            else
+                this._timeBox.show();
+        }
+    },
+
+    _setStatePlaying: function(){
+        this._playBtn.child.icon_name = 'media-playback-pause-symbolic';
+
+        this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+            GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Position']), GLib.VariantType.new("(v)"),
+            Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                try{
+                    let response = conn.call_finish(query).get_child_value(0).unpack();
+                    this._mediaPosition = response.get_int64();
+
+                    if(this._sigUpdPos == 0)
+                        this._sigUpdPos = Loop.timeout_add_seconds(1, Lang.bind(this, this._updatePosition));
+                } catch(err){
+                    //not all players support position (e.g. Nuvola) so if this exception is thrown, do nothing.
+                    if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: No such property"))
+                        throw err;
+                }
+            })
+        );
+        this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+            GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Rate']), GLib.VariantType.new("(v)"),
+            Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                try{
+                    let response = conn.call_finish(query).get_child_value(0).unpack();
+                    this._mediaRate = response.get_double();
+                } catch(err){
+                    //not all players support rate (e.g. Nuvola) so if this exception is thrown, do nothing.
+                    if(!err.message.startsWith("GDBus.Error:org.freedesktop.DBus.Error.InvalidArgs: No such property"))
+                        throw err;
+                }
+            })
+        );
+    },
+
+    _onPropChange: function(conn, sender, object, iface, signal, param, user_data){
+        if(signal == 'PropertiesChanged'){
+            let sIface = param.get_child_value(0).get_string()[0];
+
+            if(sIface == 'org.mpris.MediaPlayer2.Player'){
+                let sigs = param.get_child_value(1);
+                for(let i = 0; i < sigs.n_children(); i++){
+                    let [key, val] = sigs.get_child_value(i).unpack();
+                    key = key.get_string()[0];
+                    val = val.unpack();
+
+                    if(key == 'Metadata')
+                        this._updateMetadata(val);
+                    else if(key == 'PlaybackStatus'){
+                        let state = val.get_string()[0];
+                        if(state == 'Playing'){
+                            this._setStatePlaying();
+                        }
+                        else {
+                            if (this._sigUpdPos != 0) {
+                                Loop.source_remove(this._sigUpdPos);
+                                this._sigUpdPos = 0;
+                            }
+                            this._playBtn.child.icon_name = 'media-playback-start-symbolic';
+                        }
+                    }
+                    else if(key == 'Volume' && this._paPath != null){
+                        let vol = val.get_double();
+                        if(!this._muteVal) this._appVol = vol;
+                        if(this._paPath == null)
+                            this._volSlider.setValue(vol);
+                    }
+                }
+
+
+            }
+        } else if(signal == 'Seeked'){
+            //Have to manually get the time as banshee doesn't send it.
+            this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+                GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2.Player', 'Position']), GLib.VariantType.new("(v)"),
+                Gio.DBusCallFlags.NONE, -1, null, Lang.bind(this, function(conn, query){
+                    let response = conn.call_finish(query).get_child_value(0).unpack();
+                    this._mediaPosition = response.get_int64();
+                })
+            );
+        }
+    },
+
+    _onControlBtnClick: function(button){
+        if(button == this._playBtn){
+            this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2.Player", "PlayPause",
+                null, null, Gio.DBusCallFlags.NONE, -1, null, null);
+        }
+        else if(button == this._prevBtn){
+            this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2.Player", "Previous",
+                null, null, Gio.DBusCallFlags.NONE, -1, null, null);
+        }
+        else if(button == this._nextBtn){
+            this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2.Player", "Next",
+                null, null, Gio.DBusCallFlags.NONE, -1, null, null);
+        }
+    },
+
+    _onVolSliderKeyPress: function(actor, event) {
+        let key = event.get_key_symbol();
+
+        if(key == Clutter.KEY_space || key == Clutter.KEY_Return) {
+            this.setVolume(!this._muteVal);
+            return Clutter.EVENT_STOP;
+        }
+        return Clutter.EVENT_PROPAGATE;
+    },
+
+    _onPosSliderChange: function(slider, value, property){
+        if(this._mediaLength != 0){
+            let position = Math.floor(value * this._mediaLength);
+            this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2.Player", "SetPosition",
+                    GLib.Variant.new('(ox)', [this._mediaID, position]), null,
+                    Gio.DBusCallFlags.NONE, -1, null, null );
+        }
+    },
+
+    _updatePosition: function(){
+        if(this._mediaLength > 0 && this._mediaLength >= this._mediaPosition){
+            this._sigUpdPos = Loop.timeout_add_seconds(1, Lang.bind(this, this._updatePosition));
+
+            this._mediaPosition += 1000000*this._mediaRate;
+            this._timeLapLbl.text = this._formatSeconds(Math.floor(this._mediaPosition/1000000));
+            this._timeRemLbl.text = '-'+this._formatSeconds(Math.floor((this._mediaLength - this._mediaPosition)/1000000));
+            this._posSlider.setValue(this._mediaPosition/this._mediaLength);
+        }
+    },
+
+    _formatSeconds: function(seconds){
+        let mod = seconds % 60
+        let ans = mod.toString();
+        if(mod < 10) ans = '0'+ans;
+        seconds = Math.floor(seconds/60);
+        if(seconds > 0){
+            ans = (seconds % 60) + ':' + ans;
+            seconds = Math.floor(seconds/60);
+        }
+        else
+            ans = '0:'+ans;
+        if(seconds > 0)
+            ans = seconds +':'+ans;
+        return ans;
+    },
+
+    _raise: function(){
+        if(this._app == null){
+            this._app = WindowTracker.get_app_from_pid(this._procID);
+
+            if(this._app == null){//Check the tray
+                let trayNotifications = Main.messageTray.getSources();
+                for(let i = 0; i < trayNotifications.length; i++)
+                    if(trayNotifications[i].pid == this._procID)
+                        this._app = trayNotifications[i].app;
+            }
+
+            if(this._app == null){//try raising a window via dbus
+                this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.freedesktop.DBus.Properties", "Get",
+                    GLib.Variant.new('(ss)', ['org.mpris.MediaPlayer2', 'CanRaise']), GLib.VariantType.new("(v)"),
+                    Gio.DBusCallFlags.NONE, -1, null,
+                    Lang.bind(this, function(conn, query){
+                        let response = conn.call_finish(query).get_child_value(0).unpack();
+                        if(response.get_boolean()){
+                            this._dbus.call(this._path, '/org/mpris/MediaPlayer2', "org.mpris.MediaPlayer2", "Raise",
+                                null, null, Gio.DBusCallFlags.NONE, -1, null, null);
+                            this._app = WindowTracker.get_app_from_pid(this._procID);
+                        }
+                    })
+                );
+            }
+
+        }
+        if(this._app != null){
+            this._app.activate();
+            this._parent._getTopMenu().close(BoxPointer.PopupAnimation.FULL);
+        }
+    },
+
+    _setIcon: function(file, result){
+        if(result != null){
+            if(this._tmpIcon) this._tmpIcon.delete(null);
+            this._tmpIcon = Gio.file_new_tmp("laine.XXXXXX")[0];
+
+            let inStr = file.read_finish(result);
+            let outStr = this._tmpIcon.replace(null, false,
+                Gio.FileCreateFlags.REPLACE_DESTINATION, null, null);
+            outStr.splice(inStr,
+                Gio.OutputStreamSpliceFlags.CLOSE_SOURCE |
+                Gio.OutputStreamSpliceFlags.CLOSE_TARGET, null);
+            file = this._tmpIcon;
+        }
+
+        let icon = new Gio.FileIcon({file:file});
+        this._albumArt.set_gicon(icon);
+
+        this._albumArt.show();
+    },
+
+    _onDestroy: function(){
+        this._dbus.signal_unsubscribe(this._sigPropChange);
+        this._dbus.signal_unsubscribe(this._sigSeeked);
+        if(this._paPath){
+            this._paDBus.signal_unsubscribe(this._sigVol);
+            this._paDBus.signal_unsubscribe(this._sigMute);
+        }
+        if(this._sigUpdPos != 0) {
+            Loop.source_remove(this._sigUpdPos);
+            this._sigUpdPos = 0;
+        }
+
+        if(this._tmpIcon)
+            this._tmpIcon.delete(null);
+    }
 });

--- a/src/streamMenu.js
+++ b/src/streamMenu.js
@@ -119,7 +119,7 @@ const StreamMenu = new Lang.Class({
                 resp = resp.get_child_value(0).unpack();
 
                 let cPath = resp.get_string()[0];
-                if(cPath != path)
+                if(cPath != path && this._defaultSink != undefined)
                     this._paDBus.call(null, path, 'org.PulseAudio.Core1.Stream', 'Move',
                         GLib.Variant.new('(o)', [this._defaultSink]), null, Gio.DBusCallFlags.NONE, -1, null, null);
             })

--- a/src/streamMenu.js
+++ b/src/streamMenu.js
@@ -48,9 +48,9 @@ const StreamMenu = new Lang.Class({
 
         //Add signal handlers
         this._sigNewStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'NewPlaybackStream',
-            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onAddStream), null );
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onAddStream));
         this._sigRemStr = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1', 'PlaybackStreamRemoved',
-            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onRemoveStream), null );
+            '/org/pulseaudio/core1', null, Gio.DBusSignalFlags.NONE, Lang.bind(this, this._onRemoveStream));
 
         this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
     },
@@ -242,11 +242,11 @@ const StreamBase = new Lang.Class({
         this._sigVol = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Stream', 'VolumeUpdated',
             this._paPath, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, function(conn, sender, object, iface, signal, param, user_data){
                 this.setVolume(param.get_child_value(0));
-            }), null );
+            }));
         this._sigMute = this._paDBus.signal_subscribe(null, 'org.PulseAudio.Core1.Stream', 'MuteUpdated',
             this._paPath, null, Gio.DBusSignalFlags.NONE, Lang.bind(this, function(conn, sender, object, iface, signal, param, user_data){
                 this.setVolume(param.get_child_value(0));
-            }), null );
+            }));
     },
 
     setVolume: function(volume){
@@ -657,10 +657,10 @@ const MPRISStream = new Lang.Class({
         //Signal handlers
         this._sigPropChange = this._dbus.signal_subscribe(this._path, 'org.freedesktop.DBus.Properties',
             'PropertiesChanged', '/org/mpris/MediaPlayer2', null, Gio.DBusSignalFlags.NONE,
-            Lang.bind(this, this._onPropChange), null);
+            Lang.bind(this, this._onPropChange));
         this._sigSeeked = this._dbus.signal_subscribe(this._path, 'org.mpris.MediaPlayer2.Player',
             'Seeked', '/org/mpris/MediaPlayer2', null, Gio.DBusSignalFlags.NONE,
-            Lang.bind(this, this._onPropChange), null);
+            Lang.bind(this, this._onPropChange));
 
         this._posSlider.connect('value-changed', Lang.bind(this, this._onPosSliderChange));
 


### PR DESCRIPTION
When the default fallback sink is remove in pulseaudio, the dbus gets frozen and Laine is lost.
Calling `pacmd` unblocks dbus calls. This is mainly the changes in the portMenu.js file.

Also, pulseaudio Virtual ports are displayed.

Finally, a button to open pavucontrol can be added to the extension (enable in preferences).
A lot of diffs between the files (it's almost the only difference in streamMenu.js) is because I replaced tabs with spaces.

