### PR TITLE
Added fix to prevent Gnome Shell crash while playing videos on Chromium/Chrome

### DIFF
--- a/src/streamMenu.js
+++ b/src/streamMenu.js
@@ -841,12 +841,21 @@ var MPRISStream = new Lang.Class({
 
             if('xesam:artist' in metaD){
                 let artists = metaD['xesam:artist'];
-                let str = artists.get_child_value(0).get_string()[0];
+                let artistsType = artists.get_type();
 
-                for(let i = 1; i < artists.n_children(); i++)
-                    str += ', '+artists.get_child_value(i).get_string()[0];
+                if(artistsType.is_array()) {
+                    let str = artists.get_child_value(0).get_string()[0];
 
-                this._artistLbl.text = str;
+                    for(let i = 1; i < artists.n_children(); i++)
+                        str += ', '+artists.get_child_value(i).get_string()[0];
+
+                    this._artistLbl.text = str;
+                } else if(artistsType.is_basic()) {
+                    this._artistLbl.text = artists.get_string()[0];
+                } else {
+                    this._artistLbl.text = 'Unknown artist';
+                }
+
                 this._artistBox.show();
             } else {
                 this._artistBox.hide();


### PR DESCRIPTION
I have added a little fix in order to prevent a Gnome Shell crash when playing videos (i.e. YouTube videos) on Google Chrome or Chromium browser.

The crash was caused by Chromium's MPRIS implementation, which returns `artist` field as a `string` instead of an array of `string`. More info available here: https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/1835623

This change allows Laine to read both `string` and array of `string` values.

I know this is more a Chromium's bug instead of a Laine's bug, but I use Chrome and Laine every day and this crash was bothering me so much 😅

Thank you very much for your great work!